### PR TITLE
fix: 修复抽卡规则问题：应该只有每个限定池的首个30抽会赠送十连。

### DIFF
--- a/src/components/dashboard/DashboardView.jsx
+++ b/src/components/dashboard/DashboardView.jsx
@@ -318,19 +318,19 @@ const DashboardView = ({
           <div>
             <div className="flex justify-between text-xs mb-1">
               <span className="font-bold text-slate-600 dark:text-zinc-400 flex items-center">
-                赠送十连 (每30抽)
-                {Math.floor(stats.total / 30) > 0 && (
-                  <span className="ml-2 flex items-center gap-1 text-blue-600 font-bold bg-blue-50 dark:bg-blue-900/30 px-1.5 rounded text-[10px] border border-blue-100 dark:border-blue-800">
-                    已获 x {Math.floor(stats.total / 30)}
+                赠送十连（30抽）
+                {stats.total >= 30 && (
+                  <span className="ml-2 flex items-center gap-1 text-green-600 font-bold bg-green-50 dark:bg-green-900/30 px-1.5 rounded text-[10px] border border-green-100 dark:border-green-800">
+                    已获得
                   </span>
                 )}
               </span>
-              <span className="text-slate-400 dark:text-zinc-500">{stats.total % 30} / 30</span>
+              <span className="text-slate-400 dark:text-zinc-500">{Math.min(stats.total, 30)} / 30</span>
             </div>
             <div className="h-2 w-full bg-slate-100 rounded-sm overflow-hidden">
               <div
-                className="h-full bg-gradient-to-r from-blue-300 to-blue-500 transition-all duration-500"
-                style={{ width: `${((stats.total % 30) / 30) * 100}%` }}
+                className={`h-full transition-all duration-500 ${stats.total >= 30 ? 'bg-green-500' : 'bg-gradient-to-r from-cyan-300 to-cyan-500'}`}
+                style={{ width: `${stats.total >= 30 ? 100 : Math.min((stats.total / 30) * 100, 100)}%` }}
               ></div>
             </div>
             <div className="text-[10px] text-slate-400 dark:text-zinc-500 mt-1">

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -39,6 +39,8 @@ export const LIMITED_POOL_RULES = {
   // 赠送机制
   giftInterval: 240,                  // 每240抽赠送限定信物
   freeTenPullInterval: 30,            // 每30抽赠送不计入保底的十连
+  freeTenPullMaximum: 1,              // 赠送十连最多1次
+
   freeTenPullCountsTowardPity: false, // 赠送十连不计入保底
 
   // 情报书（仅获得1次）

--- a/src/features/simulator/LimitedPoolAnalysis.jsx
+++ b/src/features/simulator/LimitedPoolAnalysis.jsx
@@ -112,19 +112,19 @@ const LimitedPoolAnalysis = ({ currentPool, stats, effectivePity, pityInfo }) =>
           <div>
             <div className="flex justify-between text-xs mb-1">
               <span className="font-bold text-slate-600 dark:text-zinc-400 flex items-center">
-                赠送十连 (每30抽)
-                {Math.floor(stats.total / 30) > 0 && (
-                  <span className="ml-2 flex items-center gap-1 text-blue-600 font-bold bg-blue-50 dark:bg-blue-900/30 px-1.5 rounded text-[10px] border border-blue-100 dark:border-blue-800">
-                    已获 x {Math.floor(stats.total / 30)}
+                赠送十连（30抽）
+                {stats.total >= 30 && (
+                  <span className="ml-2 flex items-center gap-1 text-green-600 font-bold bg-green-50 dark:bg-green-900/30 px-1.5 rounded text-[10px] border border-green-100 dark:border-green-800">
+                    已获得
                   </span>
                 )}
               </span>
-              <span className="text-slate-400 dark:text-zinc-500">{stats.total % 30} / 30</span>
+              <span className="text-slate-400 dark:text-zinc-500">{Math.min(stats.total, 30)} / 30</span>
             </div>
             <div className="h-2 w-full bg-slate-100 rounded-sm overflow-hidden">
               <div
-                className="h-full bg-gradient-to-r from-blue-300 to-blue-500 transition-all duration-500"
-                style={{ width: `${((stats.total % 30) / 30) * 100}%` }}
+                className={`h-full transition-all duration-500 ${stats.total >= 30 ? 'bg-green-500' : 'bg-gradient-to-r from-cyan-300 to-cyan-500'}`}
+                style={{ width: `${stats.total >= 30 ? 100 : Math.min((stats.total / 30) * 100, 100)}%` }}
               ></div>
             </div>
             <div className="text-[10px] text-slate-400 dark:text-zinc-500 mt-1">

--- a/src/utils/gachaSimulator.js
+++ b/src/utils/gachaSimulator.js
@@ -310,7 +310,7 @@ export class GachaSimulator {
       };
     }
 
-    const freeTenPullCount = Math.floor(totalPulls / this.rules.freeTenPullInterval);
+    const freeTenPullCount = Math.min(Math.floor(totalPulls / this.rules.freeTenPullInterval), this.rules.freeTenPullMaximum);
     const isNewGift = freeTenPullCount > this.state.freeTenPullsReceived;
 
     return {


### PR DESCRIPTION
模拟器端进行了最小范围的改动，添加了Maximum配置项配置可获得30抽bonus的最大次数，前端参考寻访情报书进行了改动