### PR TITLE
fix: 刷新抽奖规则模板依赖

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "fflate": "^0.8.3",
         "https-proxy-agent": "^7.0.6",
         "lucide-react": "^0.555.0",
-        "open-lottery": "git+https://github.com/MoguJunn/endfield-summer-lottery.git#ad583f9110e18e5bfd48d705d816de206c6242b6",
+        "open-lottery": "git+https://github.com/MoguJunn/endfield-summer-lottery.git#a5c74774928825eb0458f3f6e193ffd23ca10d18",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-markdown": "^10.1.0",
@@ -9602,9 +9602,9 @@
       }
     },
     "node_modules/open-lottery": {
-      "version": "0.1.0",
-      "resolved": "git+https://github.com/MoguJunn/endfield-summer-lottery.git#ad583f9110e18e5bfd48d705d816de206c6242b6",
-      "integrity": "sha512-t9VTOFbIea0y+ij9M82iT0qV9lAIlDTQAYbAwroKiQc2P336XJKmQmI+SZwQquh9wET6ixEW1U+S6F1ZhSmUfg==",
+      "version": "0.1.1",
+      "resolved": "git+https://github.com/MoguJunn/endfield-summer-lottery.git#a5c74774928825eb0458f3f6e193ffd23ca10d18",
+      "integrity": "sha512-0eWGmdfzCRnRzBgUWvuBgRiHatc24owzXxj3vq/k7Suktdzdy6jRuGPKsHBzh8mCDrF/p2R0SKkgcZCqwxwN+g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/roboto-mono": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "fflate": "^0.8.3",
     "https-proxy-agent": "^7.0.6",
     "lucide-react": "^0.555.0",
-    "open-lottery": "git+https://github.com/MoguJunn/endfield-summer-lottery.git#ad583f9110e18e5bfd48d705d816de206c6242b6",
+    "open-lottery": "git+https://github.com/MoguJunn/endfield-summer-lottery.git#a5c74774928825eb0458f3f6e193ffd23ca10d18",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-markdown": "^10.1.0",


### PR DESCRIPTION
## Summary
- bump the pinned lottery template from 0.1.0 to 0.1.1
- refresh the lockfile version and integrity so Vercel installs the rules-page release instead of reusing its old Git dependency cache

## Test plan
- [x] verify the installed package reports version 0.1.1
- [x] verify the installed package contains `LOTTERY_RULES_JSON` parsing and the new rules UI
- [x] run the lottery subapp production build
