### PR TITLE
fix:优化注册弹窗移动端验证体验

### DIFF
--- a/src/components/auth/AuthModalView.jsx
+++ b/src/components/auth/AuthModalView.jsx
@@ -86,17 +86,38 @@ export default function AuthModalView({
     recoveryRequestForm.requestType === 'delete_account'
       ? tt('注销旧账号', 'Delete Old Account')
       : tt('申请人工恢复', 'Manual Recovery');
+  const submitButtonRef = React.useRef(null);
+  const captchaWasReadyRef = React.useRef(captchaReady === true);
+
+  React.useEffect(() => {
+    const becameReady = mode === 'register' && captchaReady === true && !captchaWasReadyRef.current;
+    captchaWasReadyRef.current = captchaReady === true;
+    if (!becameReady) return;
+
+    const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches;
+    const scheduleFrame = window.requestAnimationFrame || ((callback) => window.setTimeout(callback, 0));
+    scheduleFrame(() => {
+      submitButtonRef.current?.scrollIntoView({
+        behavior: reduceMotion ? 'auto' : 'smooth',
+        block: 'nearest',
+      });
+    });
+  }, [captchaReady, mode]);
 
   return (
     <div
-      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4 animate-fade-in"
+      className="auth-modal-backdrop-enter fixed inset-0 z-[80] overflow-y-auto overscroll-contain bg-black/65 p-2 backdrop-blur-sm sm:p-4"
       onClick={onClose}
     >
+      <div className="flex min-h-full items-start justify-center sm:items-center">
       <div
-        className="bg-white dark:bg-zinc-900 rounded-none shadow-2xl w-full max-w-lg overflow-hidden animate-scale-up border border-zinc-200 dark:border-zinc-800"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="auth-modal-title"
+        className="auth-modal-panel-enter my-auto flex max-h-[calc(100dvh-1rem)] w-full max-w-lg flex-col overflow-hidden rounded-none border border-zinc-200 bg-white shadow-2xl dark:border-zinc-800 dark:bg-zinc-900 sm:max-h-[calc(100dvh-2rem)]"
         onClick={(event) => event.stopPropagation()}
       >
-        <div className="relative bg-gradient-to-r from-zinc-900 to-zinc-800 dark:from-zinc-950 dark:to-zinc-900 text-white p-6 border-b-4 border-endfield-yellow">
+        <div className="relative shrink-0 border-b-4 border-endfield-yellow bg-gradient-to-r from-zinc-900 to-zinc-800 p-4 text-white dark:from-zinc-950 dark:to-zinc-900 sm:p-6">
           <div className="absolute inset-0 opacity-10 pointer-events-none">
             <div
               className="absolute inset-0"
@@ -109,24 +130,26 @@ export default function AuthModalView({
           </div>
 
           <button
+            type="button"
+            aria-label={tt('关闭账号窗口', 'Close account dialog')}
             onClick={(event) => {
               event.stopPropagation();
               onClose();
             }}
-            className="absolute top-4 right-4 text-zinc-400 hover:text-white transition-colors p-1 hover:bg-white/10 rounded z-50"
+            className="absolute right-3 top-3 z-50 p-1.5 text-zinc-400 transition-colors hover:bg-white/10 hover:text-white sm:right-4 sm:top-4"
           >
             <X size={20} />
           </button>
 
           <div className="relative z-10">
-            <div className="flex items-center gap-3 mb-2">
-              <div className="w-10 h-10 bg-endfield-yellow flex items-center justify-center">
+            <div className="mb-1.5 flex items-center gap-2.5 sm:mb-2 sm:gap-3">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center bg-endfield-yellow sm:h-10 sm:w-10">
                 {mode === 'login' ? <LogIn size={20} className="text-black" /> :
                   mode === 'register' ? <UserPlus size={20} className="text-black" /> :
                     <KeyRound size={20} className="text-black" />}
               </div>
               <div>
-                <h2 className="text-lg sm:text-xl font-bold tracking-tight font-mono">
+                <h2 id="auth-modal-title" className="font-mono text-base font-bold tracking-tight sm:text-xl">
                   {mode === 'login' ? 'SIGN IN' : mode === 'register' ? 'REGISTER' : 'ACCOUNT RECOVERY'}
                 </h2>
                 <p className="text-zinc-400 text-xs uppercase tracking-widest leading-tight">
@@ -138,7 +161,7 @@ export default function AuthModalView({
                 </p>
               </div>
             </div>
-            <p className="text-zinc-300 text-sm mt-3 leading-relaxed">
+            <p className="mt-2 pr-6 text-xs leading-relaxed text-zinc-300 sm:mt-3 sm:pr-0 sm:text-sm">
               {mode === 'login'
                 ? tt('登录以同步你的抽卡数据到云端', 'Sign in to sync your pull history to the cloud.')
                 : mode === 'register'
@@ -153,7 +176,8 @@ export default function AuthModalView({
 
         <form
           onSubmit={onSubmit}
-          className="p-6 space-y-4 bg-slate-50 dark:bg-zinc-950"
+          data-testid="auth-modal-scroll-region"
+          className="auth-modal-scroll-region min-h-0 flex-1 space-y-3 overflow-y-auto overscroll-contain bg-slate-50 p-4 max-sm:[&_input:not([type='checkbox'])]:!py-2.5 dark:bg-zinc-950 sm:space-y-4 sm:p-6"
         >
           {message && (
             <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 text-green-700 dark:text-green-400 px-4 py-3 rounded-none text-sm">
@@ -682,9 +706,10 @@ export default function AuthModalView({
           )}
 
           <button
+            ref={submitButtonRef}
             type="submit"
             disabled={submitDisabled}
-            className="w-full min-h-[48px] bg-endfield-yellow hover:bg-yellow-400 disabled:bg-yellow-300 dark:disabled:bg-yellow-600 disabled:cursor-not-allowed text-black font-bold uppercase tracking-wider py-3 rounded-none flex items-center justify-center gap-2 transition-colors shadow-lg mt-6 whitespace-normal text-center leading-tight"
+            className="mt-2 flex min-h-[48px] w-full items-center justify-center gap-2 bg-endfield-yellow py-3 text-center font-bold uppercase leading-tight tracking-wider text-black shadow-lg transition-[background-color,transform,box-shadow] hover:-translate-y-0.5 hover:bg-yellow-400 hover:shadow-xl disabled:translate-y-0 disabled:cursor-not-allowed disabled:bg-yellow-300 disabled:shadow-none dark:disabled:bg-yellow-600 sm:mt-6"
           >
             {loading ? (
               <Loader2 size={20} className="animate-spin" />
@@ -765,7 +790,7 @@ export default function AuthModalView({
           )}
         </form>
 
-        <div className="px-6 py-4 bg-white dark:bg-zinc-900 border-t border-zinc-100 dark:border-zinc-800 text-center">
+        <div className="shrink-0 border-t border-zinc-100 bg-white px-4 py-3 text-center dark:border-zinc-800 dark:bg-zinc-900 sm:px-6 sm:py-4">
           <p className="text-slate-500 dark:text-zinc-500 text-sm">
             {mode === 'login' ? (
               <>
@@ -801,6 +826,7 @@ export default function AuthModalView({
             )}
           </p>
         </div>
+      </div>
       </div>
     </div>
   );

--- a/src/components/auth/__tests__/AuthModalView.test.jsx
+++ b/src/components/auth/__tests__/AuthModalView.test.jsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import AuthModalView from '../AuthModalView.jsx';
+
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+vi.mock('../../../i18n/index.js', () => ({
+  useI18n: () => ({ isEnglish: false }),
+}));
+
+vi.mock('../../captcha/AuthCaptchaBox.jsx', () => ({
+  default: function MockAuthCaptchaBox() {
+    return <div data-testid="auth-captcha-box">安全验证</div>;
+  },
+}));
+
+function createProps(overrides = {}) {
+  const noop = vi.fn();
+
+  return {
+    agreedToTerms: true,
+    confirmPassword: 'Password123',
+    email: 'user@example.com',
+    emailCodeAction: '',
+    emailCodeLoading: false,
+    emailCodeValue: '',
+    emailDomainError: '',
+    emailLoginDisabled: false,
+    emailLoginSendCount: 0,
+    emailValid: true,
+    error: '',
+    forgotPasswordStatus: null,
+    hasEmailError: false,
+    captchaAction: 'register',
+    captchaReady: false,
+    loading: false,
+    message: '',
+    mode: 'register',
+    oauthProviders: [],
+    password: 'Password123',
+    passwordResetSendCount: 0,
+    recoveryRequestError: '',
+    recoveryRequestForm: {
+      requestType: '',
+      claimedAccountCount: 1,
+      verificationClaims: [{ gameUid: '', nickName: '' }],
+      note: '',
+    },
+    recoveryRequestLoading: false,
+    recoveryRequestSuccess: null,
+    recoverySubmitDisabled: false,
+    resendCooldown: 0,
+    showDuplicateEmailPrompt: false,
+    submitDisabled: true,
+    username: '测试用户',
+    onAddRecoveryClaim: noop,
+    onAgreedToTermsChange: noop,
+    onCaptchaStateChange: noop,
+    onClose: noop,
+    onCloseRecoveryRequest: noop,
+    onConfirmPasswordChange: noop,
+    onEmailChange: noop,
+    onEmailCodeChange: noop,
+    onEmailCodeSubmit: noop,
+    onEmailLogin: noop,
+    onOAuthLogin: noop,
+    onOpenRecoveryRequest: noop,
+    onPasswordChange: noop,
+    onRecoveryClaimChange: noop,
+    onRecoveryClaimedAccountCountChange: noop,
+    onRecoveryNoteChange: noop,
+    onRemoveRecoveryClaim: noop,
+    onSkipEmailLoginCode: noop,
+    onSkipPasswordResetEmail: noop,
+    onSubmit: noop,
+    onSubmitRecoveryRequest: noop,
+    onSwitchMode: noop,
+    onSwitchToForgotPassword: noop,
+    onSwitchToLoginWithEmail: noop,
+    onUsernameChange: noop,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  Element.prototype.scrollIntoView = originalScrollIntoView;
+  vi.restoreAllMocks();
+});
+
+describe('AuthModalView responsive registration layout', () => {
+  it('keeps the dialog inside the viewport with a dedicated scroll region', () => {
+    render(<AuthModalView {...createProps()} />);
+
+    const dialog = screen.getByRole('dialog', { name: 'REGISTER' });
+    const scrollRegion = screen.getByTestId('auth-modal-scroll-region');
+
+    expect(dialog).toHaveClass('max-h-[calc(100dvh-1rem)]', 'flex-col', 'overflow-hidden');
+    expect(scrollRegion).toHaveClass('min-h-0', 'flex-1', 'overflow-y-auto', 'p-4', 'sm:p-6');
+    expect(screen.getByTestId('auth-captcha-box')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '等待验证' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '关闭账号窗口' })).toBeEnabled();
+  });
+
+  it('moves the completed registration action into view', async () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+
+    const props = createProps();
+    const { rerender } = render(<AuthModalView {...props} />);
+    rerender(<AuthModalView {...props} captchaReady submitDisabled={false} />);
+
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        behavior: 'smooth',
+        block: 'nearest',
+      });
+    });
+    expect(screen.getByRole('button', { name: '创建账号' })).toBeEnabled();
+  });
+});

--- a/src/components/captcha/AuthCaptchaBox.jsx
+++ b/src/components/captcha/AuthCaptchaBox.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AlertTriangle, CheckCircle2, ShieldCheck } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, Loader2, ShieldCheck } from 'lucide-react';
 import {
   ensureAuthCaptchaProviderScriptLoaded,
   getAuthCaptchaClientConfig,
@@ -62,7 +62,7 @@ export default function AuthCaptchaBox({
     let cancelled = false;
     publishState('loading', {
       provider: 'pow',
-      message: tt('正在签发工作量证明挑战...', 'Issuing proof-of-work challenge...'),
+      message: tt('正在准备本地校验...', 'Preparing local verification...'),
     });
 
     createAuthPowChallenge(config.action)
@@ -71,14 +71,14 @@ export default function AuthCaptchaBox({
         setPowChallenge(challenge);
         publishState('ready', {
           provider: 'pow',
-          message: tt('请启动值守终端完成验证。', 'Start the terminal check to complete verification.'),
+          message: tt('点击“开始校验”完成验证。', 'Select Start Check to complete verification.'),
         });
       })
       .catch((error) => {
         if (cancelled) return;
         publishState('error', {
           provider: 'pow',
-          message: error?.message || tt('工作量证明挑战签发失败。', 'Failed to issue proof-of-work challenge.'),
+          message: error?.message || tt('本地校验准备失败，请改用网页验证。', 'Failed to prepare local verification. Use the web check instead.'),
         });
       });
 
@@ -118,7 +118,7 @@ export default function AuthCaptchaBox({
             sitekey: config.siteKey,
             action: config.action,
             theme: 'auto',
-            size: 'normal',
+            size: 'flexible',
             appearance: 'always',
             execution: 'render',
             callback: (token) => {
@@ -133,7 +133,7 @@ export default function AuthCaptchaBox({
               if (cancelled) return;
               publishState('error', {
                 provider: 'turnstile',
-                message: tt(`Turnstile 验证失败：${code || 'unknown'}。你可以改用值守终端。`, `Turnstile failed: ${code || 'unknown'}. You can use terminal PoW instead.`),
+                message: tt(`网页验证失败：${code || 'unknown'}。你可以改用本地校验。`, `Web verification failed: ${code || 'unknown'}. You can use the local check instead.`),
               });
             },
             'expired-callback': () => {
@@ -175,10 +175,32 @@ export default function AuthCaptchaBox({
     };
   }, [config, mode, publishState, tt]);
 
+  const selectMode = React.useCallback((nextMode) => {
+    if (nextMode === mode) return;
+
+    setPowChallenge(null);
+    publishState('loading', {
+      provider: nextMode,
+      message: nextMode === 'pow'
+        ? tt('正在准备本地校验...', 'Preparing local verification...')
+        : tt('正在准备网页验证...', 'Preparing web verification...'),
+    });
+    setMode(nextMode);
+  }, [mode, publishState, tt]);
+
   if (!config.enabled) {
     return null;
   }
 
+  const statusLabel = status === 'success'
+    ? tt('已完成', 'Complete')
+    : status === 'error' || status === 'expired'
+      ? tt('需重试', 'Try Again')
+      : status === 'loading'
+        ? tt('载入中', 'Loading')
+        : status === 'ready'
+          ? tt('待操作', 'Action Needed')
+          : tt('准备中', 'Preparing');
   const statusTone = status === 'success'
     ? 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-300'
     : status === 'error' || status === 'expired'
@@ -186,53 +208,101 @@ export default function AuthCaptchaBox({
       : 'border-zinc-200 bg-white text-slate-600 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300';
 
   return (
-    <div className={`border rounded-none p-3 ${statusTone}`}>
-      <div className="mb-3 flex items-start gap-2">
-        {status === 'success' ? <CheckCircle2 size={17} className="mt-0.5 shrink-0" /> : status === 'error' || status === 'expired' ? <AlertTriangle size={17} className="mt-0.5 shrink-0" /> : <ShieldCheck size={17} className="mt-0.5 shrink-0" />}
-        <div className="flex-1">
+    <section
+      aria-label={tt('安全验证', 'Security verification')}
+      data-status={status}
+      className={`min-w-0 overflow-hidden border p-2.5 transition-colors duration-200 sm:p-3 ${statusTone}`}
+    >
+      <div className="flex items-start gap-2.5">
+        <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center border border-current/20 bg-white/55 dark:bg-black/15">
+          {status === 'success' ? (
+            <CheckCircle2 size={16} />
+          ) : status === 'error' || status === 'expired' ? (
+            <AlertTriangle size={16} />
+          ) : status === 'loading' ? (
+            <Loader2 size={16} className="animate-spin" />
+          ) : (
+            <ShieldCheck size={16} />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <div className="text-xs font-bold uppercase tracking-wider">
-              {mode === 'pow' ? tt('值守终端验证', 'Terminal PoW Check') : tt('人机验证', 'Bot Check')}
+            <div>
+              <div className="text-xs font-bold uppercase tracking-[0.14em]">
+                {tt('安全验证', 'Security Check')}
+              </div>
+              <div className="mt-0.5 text-[10px] uppercase tracking-wider opacity-70">
+                {mode === 'pow' ? tt('本地校验', 'Local Check') : tt('网页验证', 'Web Check')}
+              </div>
             </div>
-            {canUseTurnstile(config) && (
-              <button
-                type="button"
-                onClick={() => {
-                  setPowChallenge(null);
-                  setMode((current) => (current === 'pow' ? 'turnstile' : 'pow'));
-                }}
-                className="text-[11px] font-bold uppercase tracking-wider text-endfield-yellow hover:text-yellow-500"
-              >
-                {mode === 'pow' ? tt('使用 Turnstile', 'Use Turnstile') : tt('改用 PoW', 'Use PoW')}
-              </button>
-            )}
+            <span className="border border-current/20 bg-white/60 px-2 py-1 text-[10px] font-bold uppercase tracking-wider dark:bg-black/15">
+              {statusLabel}
+            </span>
           </div>
-          <p className="mt-0.5 text-xs leading-relaxed">
+          <p aria-live="polite" className="mt-1 text-xs leading-relaxed">
             {message || tt('请完成下方验证后继续。', 'Complete the verification below before continuing.')}
           </p>
         </div>
       </div>
 
-      {mode === 'turnstile' && canUseTurnstile(config) && (
-        <div className="min-h-[70px] overflow-hidden">
-          <div ref={containerRef} />
+      {canUseTurnstile(config) && (
+        <div role="group" aria-label={tt('选择验证方式', 'Choose verification method')} className="mt-2.5 grid grid-cols-2 border border-current/15 bg-white/50 p-0.5 dark:bg-black/10">
+          <button
+            type="button"
+            aria-pressed={mode === 'turnstile'}
+            onClick={() => selectMode('turnstile')}
+            className={`min-h-[38px] px-2 py-1.5 text-left transition-[background-color,color,box-shadow] ${
+              mode === 'turnstile'
+                ? 'bg-zinc-900 text-white shadow-sm dark:bg-zinc-100 dark:text-zinc-950'
+                : 'text-current hover:bg-white/70 dark:hover:bg-white/10'
+            }`}
+          >
+            <span className="block text-[11px] font-bold">{tt('网页验证', 'Web Check')}</span>
+            <span className="mt-0.5 block text-[9px] opacity-70">{tt('推荐 · 快速完成', 'Recommended · Quick')}</span>
+          </button>
+          <button
+            type="button"
+            aria-pressed={mode === 'pow'}
+            onClick={() => selectMode('pow')}
+            className={`min-h-[38px] px-2 py-1.5 text-left transition-[background-color,color,box-shadow] ${
+              mode === 'pow'
+                ? 'bg-zinc-900 text-white shadow-sm dark:bg-zinc-100 dark:text-zinc-950'
+                : 'text-current hover:bg-white/70 dark:hover:bg-white/10'
+            }`}
+          >
+            <span className="block text-[11px] font-bold">{tt('本地校验', 'Local Check')}</span>
+            <span className="mt-0.5 block text-[9px] opacity-70">{tt('网络不稳时使用', 'For unstable networks')}</span>
+          </button>
         </div>
       )}
 
-      {mode === 'pow' && powChallenge && (
-        <TerminalPowCaptcha
-          action={config.action}
-          challenge={powChallenge}
-          onVerified={(powPayload) => {
-            publishState('success', {
-              provider: 'pow',
-              powPayload,
-              message: tt('值守终端验证已完成。', 'Terminal PoW check completed.'),
-            });
-          }}
-          showFallbackButton={false}
-        />
-      )}
-    </div>
+      <div key={mode} className="auth-verification-panel-enter mt-2.5 min-w-0">
+        {mode === 'turnstile' && canUseTurnstile(config) && (
+          <div className="min-h-[68px] w-full min-w-0 overflow-x-auto">
+            <div ref={containerRef} className="w-full min-w-0" />
+          </div>
+        )}
+
+        {mode === 'pow' && powChallenge && (
+          <TerminalPowCaptcha
+            action={config.action}
+            challenge={powChallenge}
+            compact
+            onVerified={(powPayload) => {
+              publishState('success', {
+                provider: 'pow',
+                powPayload,
+                message: tt('本地校验已完成，可以创建账号。', 'Local check completed. You can create the account.'),
+              });
+            }}
+            showFallbackButton={false}
+          />
+        )}
+      </div>
+
+      <p className="mt-2 text-[10px] leading-relaxed opacity-65">
+        {tt('验证完成后页面会自动定位到“创建账号”按钮。', 'After verification, the page moves to the Create Account button automatically.')}
+      </p>
+    </section>
   );
 }

--- a/src/components/captcha/TerminalPowCaptcha.jsx
+++ b/src/components/captcha/TerminalPowCaptcha.jsx
@@ -59,6 +59,7 @@ export default function TerminalPowCaptcha({
   onVerified,
   onUseMinecraft,
   isMobile = false,
+  compact = false,
   showFallbackButton = true,
 }) {
   const effectiveChallenge = useMemo(() => challenge || createLocalPowChallenge({
@@ -124,7 +125,7 @@ export default function TerminalPowCaptcha({
   const startPow = useCallback(() => {
     if (!supportsPow) {
       setStatus('error');
-      setError('当前环境无法启动值守终端，可暂时改用 MC 合成验证。');
+      setError(compact ? '当前环境无法启动本地校验，请改用网页验证。' : '当前环境无法启动值守终端，可暂时改用 MC 合成验证。');
       return;
     }
 
@@ -175,13 +176,13 @@ export default function TerminalPowCaptcha({
 
       cleanupWorker();
       setStatus('error');
-      setError('值守终端未能在预期时间内完成核验，请重试或改用 MC 合成验证。');
+      setError(compact ? '本地校验未能完成，请重试或改用网页验证。' : '值守终端未能在预期时间内完成核验，请重试或改用 MC 合成验证。');
     };
 
     worker.onerror = () => {
       cleanupWorker();
       setStatus('error');
-      setError('值守终端暂时无法响应，可改用 MC 合成验证。');
+      setError(compact ? '本地校验暂时无法响应，请改用网页验证。' : '值守终端暂时无法响应，可改用 MC 合成验证。');
     };
 
     worker.postMessage({
@@ -190,7 +191,7 @@ export default function TerminalPowCaptcha({
       totalSteps: config.totalSteps,
       progressInterval: config.progressInterval,
     });
-  }, [cleanupWorker, config.progressInterval, config.rounds, config.totalSteps, effectiveChallenge, onVerified, supportsPow]);
+  }, [cleanupWorker, compact, config.progressInterval, config.rounds, config.totalSteps, effectiveChallenge, onVerified, supportsPow]);
 
   const handlePrimaryAction = () => {
     if (status === 'running' || status === 'finalizing') {
@@ -227,22 +228,22 @@ export default function TerminalPowCaptcha({
       : 0;
 
   return (
-    <div className="mx-auto w-full max-w-[360px] font-mono">
-      <div className="flex items-center justify-between border border-zinc-700 border-b-0 bg-zinc-900 px-3 py-2">
+    <div className={`mx-auto w-full font-mono ${compact ? 'max-w-none' : 'max-w-[360px]'}`}>
+      <div className={`flex items-center justify-between gap-2 border border-zinc-700 border-b-0 bg-zinc-900 ${compact ? 'px-2.5 py-1.5' : 'px-3 py-2'}`}>
         <div className="flex items-center gap-2 text-xs tracking-[0.16em] text-endfield-yellow">
           <TerminalSquare className="h-3.5 w-3.5" />
-          <span>边境值守终端</span>
+          <span>{compact ? '本地校验终端' : '边境值守终端'}</span>
         </div>
-        <span className="text-[10px] text-zinc-500">记录 {sessionId}</span>
+        <span className="truncate text-[9px] text-zinc-500 sm:text-[10px]">{compact ? sessionId : `记录 ${sessionId}`}</span>
       </div>
 
-      <div className="border border-zinc-700 bg-black p-4">
-        <div className="grid gap-3 text-xs text-zinc-400">
-          <div className="grid grid-cols-[88px,1fr] gap-2">
+      <div className={`border border-zinc-700 bg-black ${compact ? 'p-2.5 sm:p-3' : 'p-4'}`}>
+        <div className={`grid text-xs text-zinc-400 ${compact ? 'gap-2' : 'gap-3'}`}>
+          <div className={`grid grid-cols-[88px,1fr] gap-2 ${compact ? 'hidden sm:grid' : ''}`}>
             <span className="text-zinc-600">当前节点</span>
             <span className="text-endfield-yellow">外环值守通道</span>
           </div>
-          <div className="grid grid-cols-[88px,1fr] gap-2">
+          <div className={`grid grid-cols-[88px,1fr] gap-2 ${compact ? 'hidden sm:grid' : ''}`}>
             <span className="text-zinc-600">登记编号</span>
             <span className="text-zinc-300">{sessionId}</span>
           </div>
@@ -258,14 +259,14 @@ export default function TerminalPowCaptcha({
           </div>
         </div>
 
-        <div className="mt-4 border border-zinc-800 bg-zinc-950/80 p-3 text-xs text-zinc-400">
+        <div aria-live="polite" className={`border border-zinc-800 bg-zinc-950/80 text-xs text-zinc-400 ${compact ? 'mt-2.5 p-2.5' : 'mt-4 p-3'}`}>
           {status === 'running' || status === 'finalizing' ? (
             <div className="space-y-2">
               <div className="flex items-center gap-2 text-endfield-yellow">
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
                 <span>{status === 'finalizing' ? '核验完成，正在写入通行回执。' : '值守终端正在核对来访记录，请稍候。'}</span>
               </div>
-              <div className="text-zinc-300">
+              <div className={`text-zinc-300 ${compact ? 'hidden sm:block' : ''}`}>
                 {status === 'finalizing'
                   ? '值守信标已完成最后一次回响，终端会短暂停留后放行。'
                   : '边境识别程序已展开，值守信标正在逐段回应你的通行请求。'}
@@ -273,8 +274,8 @@ export default function TerminalPowCaptcha({
               <div className="overflow-hidden border border-zinc-800 bg-black/70">
                 <div className="h-1.5 bg-endfield-yellow/70 transition-[width] duration-300" style={{ width: `${progressPercent}%` }} />
               </div>
-              <div className="flex justify-between text-zinc-500">
-                <span>请保持当前界面，等待值守终端完成回执。</span>
+              <div className="flex justify-between gap-2 text-zinc-500">
+                <span>{compact ? '请保持当前页面。' : '请保持当前界面，等待值守终端完成回执。'}</span>
                 <span>{progressPercent}%</span>
               </div>
             </div>
@@ -285,22 +286,22 @@ export default function TerminalPowCaptcha({
                 <span>核验完成，通路已开启。</span>
               </div>
               <div className="text-zinc-300">值守终端已确认你的来访记录，正在发回通行许可。</div>
-              <div className="text-zinc-500">本次值守回执已记入边境档案。</div>
+              {!compact && <div className="text-zinc-500">本次值守回执已记入边境档案。</div>}
             </div>
           ) : (
             <div className="space-y-2">
-              <div className="text-zinc-300">启动值守终端后，边境识别程序会短暂核对来访记录。通过后将直接放行。</div>
+              <div className="text-zinc-300">{compact ? '点击开始后，本机将进行数秒校验；验证数据不会离开当前流程。' : '启动值守终端后，边境识别程序会短暂核对来访记录。通过后将直接放行。'}</div>
               {error ? <div className="text-red-400">{error}</div> : null}
             </div>
           )}
         </div>
 
-        <div className="mt-4 flex flex-wrap gap-2">
+        <div className={`flex flex-wrap gap-2 ${compact ? 'mt-2.5' : 'mt-4'}`}>
           <button
             type="button"
             onClick={handlePrimaryAction}
             disabled={status === 'running' || status === 'finalizing'}
-            className="inline-flex items-center gap-2 border border-endfield-yellow px-4 py-2 text-xs font-bold tracking-[0.18em] text-endfield-yellow transition-colors hover:bg-endfield-yellow hover:text-black disabled:cursor-wait disabled:opacity-60"
+            className={`inline-flex min-h-[40px] items-center justify-center gap-2 border border-endfield-yellow px-4 py-2 text-xs font-bold tracking-[0.18em] text-endfield-yellow transition-colors hover:bg-endfield-yellow hover:text-black disabled:cursor-wait disabled:opacity-60 ${compact ? 'w-full sm:w-auto' : ''}`}
           >
             {status === 'idle' ? '开始校验' : status === 'done' ? '重置终端' : status === 'finalizing' ? '写入回执' : '再次校验'}
             {status === 'idle' ? <ArrowRight className="h-3.5 w-3.5" /> : null}
@@ -317,10 +318,12 @@ export default function TerminalPowCaptcha({
         </div>
       </div>
 
-      <div className="mt-1 flex justify-between px-1 text-[9px] text-zinc-600">
-        <span>边境值守记录</span>
-        <span>{supportsPow ? '终端在线' : '终端离线'}</span>
-      </div>
+      {!compact && (
+        <div className="mt-1 flex justify-between px-1 text-[9px] text-zinc-600">
+          <span>边境值守记录</span>
+          <span>{supportsPow ? '终端在线' : '终端离线'}</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/captcha/__tests__/AuthCaptchaBox.test.jsx
+++ b/src/components/captcha/__tests__/AuthCaptchaBox.test.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AuthCaptchaBox from '../AuthCaptchaBox.jsx';
+import {
+  ensureAuthCaptchaProviderScriptLoaded,
+  getAuthCaptchaClientConfig,
+} from '../../../services/authCaptchaClient.js';
+import { createAuthPowChallenge } from '../../../services/powChallengeService.js';
+
+vi.mock('../../../i18n/index.js', () => ({
+  useI18n: () => ({ isEnglish: false }),
+}));
+
+vi.mock('../../../services/authCaptchaClient.js', () => ({
+  ensureAuthCaptchaProviderScriptLoaded: vi.fn(),
+  getAuthCaptchaClientConfig: vi.fn(),
+}));
+
+vi.mock('../../../services/powChallengeService.js', () => ({
+  createAuthPowChallenge: vi.fn(),
+}));
+
+const CHALLENGE = {
+  action: 'register',
+  algorithm: 'sha256-chain-v1',
+  challengeId: 'challenge-1',
+  difficulty: 1,
+  expiresAt: Date.now() + 60_000,
+  issuedAt: Date.now(),
+  seed: 'seed',
+  signature: 'signature',
+  totalSteps: 10,
+};
+
+function renderCaptcha(onStateChange = vi.fn()) {
+  return {
+    onStateChange,
+    ...render(<AuthCaptchaBox action="register" onStateChange={onStateChange} />),
+  };
+}
+
+describe('AuthCaptchaBox verification presentation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAuthCaptchaClientConfig.mockReturnValue({
+      action: 'register',
+      configured: true,
+      enabled: true,
+      provider: 'turnstile',
+      required: true,
+      siteKey: 'site-key',
+    });
+    ensureAuthCaptchaProviderScriptLoaded.mockResolvedValue(true);
+    createAuthPowChallenge.mockResolvedValue(CHALLENGE);
+    window.turnstile = {
+      remove: vi.fn(),
+      render: vi.fn(() => 'widget-1'),
+    };
+  });
+
+  it('shows clear provider choices and uses a flexible web widget', async () => {
+    renderCaptcha();
+
+    const webButton = screen.getByRole('button', { name: /网页验证/ });
+    const localButton = screen.getByRole('button', { name: /本地校验/ });
+
+    expect(webButton).toHaveAttribute('aria-pressed', 'true');
+    expect(localButton).toHaveAttribute('aria-pressed', 'false');
+
+    await waitFor(() => expect(window.turnstile.render).toHaveBeenCalled());
+    expect(window.turnstile.render.mock.calls[0][1]).toMatchObject({
+      action: 'register',
+      size: 'flexible',
+    });
+  });
+
+  it('switches to the compact local check without hiding its action', async () => {
+    const { onStateChange } = renderCaptcha();
+
+    fireEvent.click(screen.getByRole('button', { name: /本地校验/ }));
+
+    expect(await screen.findByText('本地校验终端')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '开始校验' })).toBeVisible();
+    expect(screen.getByRole('button', { name: /本地校验/ })).toHaveAttribute('aria-pressed', 'true');
+    expect(onStateChange).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'register',
+      provider: 'pow',
+      ready: false,
+      status: 'ready',
+    }));
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -618,6 +618,60 @@
     animation: scale-up 0.2s ease-out forwards;
   }
 
+  /* 认证弹窗：短促进场、视口内滚动和验证方式切换 */
+  @keyframes auth-modal-backdrop-enter {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  @keyframes auth-modal-panel-enter {
+    from {
+      opacity: 0;
+      transform: translateY(14px) scale(0.975);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  @keyframes auth-verification-panel-enter {
+    from {
+      opacity: 0;
+      transform: translateY(6px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .auth-modal-backdrop-enter {
+    animation: auth-modal-backdrop-enter 160ms ease-out both;
+  }
+
+  .auth-modal-panel-enter {
+    animation: auth-modal-panel-enter 220ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+    transform-origin: center;
+  }
+
+  .auth-verification-panel-enter {
+    animation: auth-verification-panel-enter 180ms ease-out both;
+  }
+
+  .auth-modal-scroll-region {
+    -webkit-overflow-scrolling: touch;
+    scrollbar-gutter: stable;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .auth-modal-backdrop-enter,
+    .auth-modal-panel-enter,
+    .auth-verification-panel-enter {
+      animation: none;
+    }
+  }
+
   /* 从右侧滑入 */
   @keyframes slide-in-right {
     from {


### PR DESCRIPTION
## Summary
- 让注册弹窗受动态视口高度约束，表单独立滚动，确保小屏展开验证后仍可触达提交按钮
- 将网页验证与本地校验改为明确选项，补充验证状态、紧凑终端与验证完成后的自动定位
- 增加减少动态效果支持，以及弹窗布局和验证方式切换的定向回归测试

## Test plan
- [x] 注册弹窗与验证组件定向测试（4/4）
- [x] ESLint
- [x] 主站与抽奖页生产构建
- [x] 320×568、375×667、390×844 手机视口操作可达性检查