### PR TITLE
fix: 修复正式导入原子提交回归

### DIFF
--- a/api/__tests__/fullImportService.test.js
+++ b/api/__tests__/fullImportService.test.js
@@ -649,6 +649,7 @@ describe('executeFullImport import mode metadata', () => {
     };
     await expect(savePostImportAnomalies(supabase, stagedRecords, 'user-1')).resolves.toEqual({
       anomalyRecords: 1,
+      skippedAnomalyRecords: 0,
       anomalyPoolIds: ['special_test'],
       anomalyItems: [expect.objectContaining({
         recordId: 'record-unknown',
@@ -664,6 +665,68 @@ describe('executeFullImport import mode metadata', () => {
         ignoreDuplicates: true,
       }
     );
+  });
+
+  it('isolates an anomaly with no matching history parent without dropping valid markers', async () => {
+    const { savePostImportAnomalies } = await import('../../backend/fullImportService.js');
+    const issues = [{ code: 'MISSING_ITEM_NAME', severity: 'review' }];
+    const stagedRecords = [
+      {
+        historyRecord: {
+          record_id: 'record-valid',
+          game_uid: '10001',
+          server_id: '1',
+          pool_id: 'special_test',
+          seq_id: '42',
+          rarity: 4,
+          timestamp: '2026-07-16T12:00:00.000Z',
+        },
+        issues,
+      },
+      {
+        historyRecord: {
+          record_id: 'record-missing-parent',
+          game_uid: '10001',
+          server_id: '1',
+          pool_id: 'special_test',
+          seq_id: '43',
+          rarity: 4,
+          timestamp: '2026-07-16T12:01:00.000Z',
+        },
+        issues,
+      },
+    ];
+    const parentError = {
+      code: '23503',
+      message: 'violates foreign key constraint "history_anomalies_user_id_game_uid_server_scope_pool_id_se_fkey"',
+    };
+    const upsert = vi.fn(async (rows) => {
+      if (rows.length > 1 || rows[0]?.record_id === 'record-missing-parent') {
+        return { error: parentError };
+      }
+      return { error: null };
+    });
+    const supabase = {
+      from: vi.fn(() => ({ upsert })),
+    };
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(savePostImportAnomalies(supabase, stagedRecords, 'user-1')).resolves.toEqual({
+      anomalyRecords: 1,
+      skippedAnomalyRecords: 1,
+      anomalyPoolIds: ['special_test'],
+      anomalyItems: [expect.objectContaining({
+        recordId: 'record-valid',
+        poolId: 'special_test',
+        seqId: '42',
+      })],
+    });
+    expect(upsert).toHaveBeenCalledTimes(3);
+    expect(warn).toHaveBeenCalledWith(
+      '[FullImportService] 跳过无法匹配正式历史的异常提醒:',
+      1
+    );
+    warn.mockRestore();
   });
 
   it('recognizes only an exact unknown four-star artifact at the official non-pull locator', async () => {

--- a/api/__tests__/historyReviewMigrations.test.js
+++ b/api/__tests__/historyReviewMigrations.test.js
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 function readMigration(name) {
@@ -13,6 +13,37 @@ function readBaseline() {
 
 function readBackfillScript() {
   return readFileSync(new URL('../../scripts/backfill-history-anomalies.mjs', import.meta.url), 'utf8');
+}
+
+function readMissingOfficialImportAnomalyRepair() {
+  return readFileSync(
+    new URL(
+      '../../supabase/manual/data-backfill/170_backfill_missing_official_import_anomalies.sql',
+      import.meta.url
+    ),
+    'utf8'
+  );
+}
+
+function readLatestOfficialImportCommitMigration() {
+  const migrationDirectory = new URL('../../supabase/migrations/', import.meta.url);
+  const migrationNames = readdirSync(migrationDirectory)
+    .filter((name) => /^\d+_.+\.sql$/i.test(name))
+    .sort((left, right) => {
+      const leftNumber = Number(left.match(/^(\d+)/)?.[1] || 0);
+      const rightNumber = Number(right.match(/^(\d+)/)?.[1] || 0);
+      return leftNumber - rightNumber || left.localeCompare(right);
+    });
+  let latest = null;
+
+  migrationNames.forEach((name) => {
+    const sql = readMigration(name);
+    if (sql.includes('CREATE OR REPLACE FUNCTION public.commit_official_import_records')) {
+      latest = { name, sql };
+    }
+  });
+
+  return latest;
 }
 
 describe('history review database migrations', () => {
@@ -53,6 +84,28 @@ describe('history review database migrations', () => {
     expect(sql).toMatch(/GRANT EXECUTE ON FUNCTION public\.commit_official_import_records[\s\S]+TO service_role;/);
   });
 
+  it('keeps the latest official import commit aligned with the server-scoped history key', () => {
+    const latest = readLatestOfficialImportCommitMigration();
+    expect(latest).not.toBeNull();
+
+    const normalizedSql = latest.sql.replace(/\s+/g, ' ');
+    expect(normalizedSql).toContain(
+      'ON CONFLICT (user_id, game_uid, server_scope, pool_id, seq_id)'
+    );
+    expect(normalizedSql).not.toContain(
+      'ON CONFLICT (user_id, game_uid, server_id, pool_id, seq_id, record_id)'
+    );
+    expect(normalizedSql).toContain('IF NOT public.is_account_credential_allowed(p_user_id)');
+    expect(normalizedSql).toContain("v_task.summary ->> 'newRecords'");
+    expect(normalizedSql).toContain('nick_name, rarity, character_name, item_name, character_id');
+    expect(normalizedSql).toContain('pity, is_free, is_info_book, is_new, is_standard');
+    expect(normalizedSql).toContain('server_id, region, batch_id, special_type');
+    expect(normalizedSql).toContain('committed_at = NOW()');
+    expect(normalizedSql).toContain("AND status = 'confirming'");
+    expect(normalizedSql).toContain('official_import_history_conflict_constraint_missing');
+    expect(normalizedSql).toContain('official_import_history_conflict_target_invalid');
+  });
+
   it('rejects ambiguous legacy batch deletion before deleting exact locked rows', () => {
     const sql = readMigration('155_guard_ambiguous_history_batch_delete.sql');
 
@@ -69,6 +122,7 @@ describe('history review database migrations', () => {
     const baseline = readBaseline();
 
     expect(baseline).toContain('active/153_commit_official_import_records_atomically.sql');
+    expect(baseline).toContain('active/170_restore_official_import_atomic_commit.sql');
     expect(baseline).toContain('active/155_guard_ambiguous_history_batch_delete.sql');
     expect(baseline).toContain('CREATE OR REPLACE FUNCTION public.update_history_record_controlled');
     expect(baseline).toContain('CREATE OR REPLACE FUNCTION public.commit_official_import_records');
@@ -87,5 +141,22 @@ describe('history review database migrations', () => {
     expect(script).toContain('CONFIRM_HISTORY_ANOMALY_BACKFILL');
     expect(script).toContain('const APPLY_CONFIRMATION = `${EXPECTED_RECORDS}:${EXPECTED_USERS}`;');
     expect(script).toContain('await verifyAnomalyMarkers(client, anomalies);');
+  });
+
+  it('repairs missing official-import anomaly markers from exact history parent rows', () => {
+    const sql = readMissingOfficialImportAnomalyRepair();
+    const normalizedSql = sql.replace(/\s+/g, ' ');
+
+    expect(normalizedSql).toContain('IF v_candidate_count <> 10 THEN');
+    expect(normalizedSql).toContain('INSERT INTO public.history_anomalies');
+    expect(normalizedSql).toContain('FROM public.history AS history_row');
+    expect(normalizedSql).toContain("anomaly.issue_code = 'OFFICIAL_IMPORT_UNKNOWN_ITEM'");
+    expect(normalizedSql).toContain("history_row.rarity = 4");
+    expect(normalizedSql).toContain('history_row.special_type IS NULL');
+    expect(normalizedSql).toContain(
+      'ON CONFLICT (user_id, game_uid, server_scope, pool_id, seq_id, issue_code) DO NOTHING'
+    );
+    expect(normalizedSql).toContain("'repairSource', 'production_repair_2026_08_03'");
+    expect(normalizedSql).toContain('IF v_inserted_count <> v_candidate_count THEN');
   });
 });

--- a/backend/fullImportService.js
+++ b/backend/fullImportService.js
@@ -945,6 +945,52 @@ export function buildPostImportAnomalyItems(anomalyRows = []) {
   }));
 }
 
+const HISTORY_ANOMALY_PARENT_CONSTRAINT =
+  'history_anomalies_user_id_game_uid_server_scope_pool_id_se_fkey';
+
+function isMissingHistoryAnomalyParentError(error) {
+  if (String(error?.code || '') !== '23503') {
+    return false;
+  }
+
+  return [error?.constraint, error?.message, error?.details]
+    .some((value) => String(value || '').includes(HISTORY_ANOMALY_PARENT_CONSTRAINT));
+}
+
+async function upsertPostImportAnomalyBatch(supabase, anomalyRows) {
+  const rows = Array.isArray(anomalyRows) ? anomalyRows : [];
+  if (rows.length === 0) {
+    return { savedRows: [], skippedRows: [] };
+  }
+
+  const { error } = await supabase
+    .from('history_anomalies')
+    .upsert(rows, {
+      onConflict: 'user_id,game_uid,server_scope,pool_id,seq_id,issue_code',
+      ignoreDuplicates: true,
+    });
+
+  if (!error) {
+    return { savedRows: rows, skippedRows: [] };
+  }
+  if (!isMissingHistoryAnomalyParentError(error)) {
+    throw error;
+  }
+  if (rows.length === 1) {
+    return { savedRows: [], skippedRows: rows };
+  }
+
+  const midpoint = Math.ceil(rows.length / 2);
+  const [left, right] = await Promise.all([
+    upsertPostImportAnomalyBatch(supabase, rows.slice(0, midpoint)),
+    upsertPostImportAnomalyBatch(supabase, rows.slice(midpoint)),
+  ]);
+  return {
+    savedRows: [...left.savedRows, ...right.savedRows],
+    skippedRows: [...left.skippedRows, ...right.skippedRows],
+  };
+}
+
 export function resolveOfficialImportStorageQuality(normalized = {}) {
   if (
     normalized.quality === null
@@ -958,20 +1004,29 @@ export function resolveOfficialImportStorageQuality(normalized = {}) {
 
 export async function savePostImportAnomalies(supabase, stagedRecords, userId) {
   const anomalyRows = buildPostImportAnomalyRows(stagedRecords, userId);
+  const savedRows = [];
+  const skippedRows = [];
   for (let index = 0; index < anomalyRows.length; index += 200) {
-    const { error } = await supabase
-      .from('history_anomalies')
-      .upsert(anomalyRows.slice(index, index + 200), {
-        onConflict: 'user_id,game_uid,server_scope,pool_id,seq_id,issue_code',
-        ignoreDuplicates: true,
-      });
-    if (error) throw error;
+    const result = await upsertPostImportAnomalyBatch(
+      supabase,
+      anomalyRows.slice(index, index + 200)
+    );
+    savedRows.push(...result.savedRows);
+    skippedRows.push(...result.skippedRows);
+  }
+
+  if (skippedRows.length > 0) {
+    console.warn(
+      '[FullImportService] 跳过无法匹配正式历史的异常提醒:',
+      skippedRows.length
+    );
   }
 
   return {
-    anomalyRecords: anomalyRows.length,
-    anomalyPoolIds: [...new Set(anomalyRows.map((row) => row.pool_id))],
-    anomalyItems: buildPostImportAnomalyItems(anomalyRows),
+    anomalyRecords: savedRows.length,
+    skippedAnomalyRecords: skippedRows.length,
+    anomalyPoolIds: [...new Set(savedRows.map((row) => row.pool_id))],
+    anomalyItems: buildPostImportAnomalyItems(savedRows),
   };
 }
 
@@ -2124,7 +2179,12 @@ export async function executeFullImport({
         .map((record) => Number(record.ordinal))
     );
     const writtenStagedRecords = processedResult.stagedRecords.filter((_record, ordinal) => writtenOrdinals.has(ordinal));
-    let anomalyResult = { anomalyRecords: 0, anomalyPoolIds: [], anomalyItems: [] };
+    let anomalyResult = {
+      anomalyRecords: 0,
+      skippedAnomalyRecords: 0,
+      anomalyPoolIds: [],
+      anomalyItems: [],
+    };
     let anomalyWarning = null;
     try {
       anomalyResult = await savePostImportAnomalies(supabase, writtenStagedRecords, userId);
@@ -2152,12 +2212,16 @@ export async function executeFullImport({
         savedRecords: Number(commitResult.savedRecords || 0),
         skippedRecords,
         anomalyRecords: anomalyResult.anomalyRecords,
+        skippedAnomalyRecords: anomalyResult.skippedAnomalyRecords,
         anomalyPoolIds: anomalyResult.anomalyPoolIds,
         anomalyItems: anomalyResult.anomalyItems,
         warnings: [
           ...nonPullRepairResult.warnings,
           ...(anomalyResult.anomalyRecords > 0
             ? [`有 ${anomalyResult.anomalyRecords} 条已导入记录需要后续核对。`]
+            : []),
+          ...(anomalyResult.skippedAnomalyRecords > 0
+            ? [`有 ${anomalyResult.skippedAnomalyRecords} 条核对提醒找不到对应的正式记录，已跳过提醒创建。`]
             : []),
           ...(skippedRecords > 0
             ? [`有 ${skippedRecords} 条记录缺少卡池、账号、序号、时间或有效品质，无法安全写入。`]

--- a/scripts/verify-supabase-baseline-smoke.mjs
+++ b/scripts/verify-supabase-baseline-smoke.mjs
@@ -226,6 +226,206 @@ SELECT 'weapon_avg_target=' || COALESCE(((public.get_global_stats())::jsonb -> '
 `.trim();
 }
 
+function buildOfficialImportCommitFixtureSql() {
+  return `
+DO $fixture$
+DECLARE
+  v_result JSONB;
+  v_user_id UUID := '00000000-0000-0000-0000-000000000001';
+BEGIN
+  INSERT INTO public.official_import_tasks (
+    id,
+    user_id,
+    source,
+    import_mode,
+    game_uid,
+    server_id,
+    status,
+    access_key_hash,
+    summary
+  ) VALUES (
+    '00000000-0000-0000-0000-000000000101',
+    v_user_id,
+    'cn',
+    'incremental',
+    'rpc-game-1',
+    '1',
+    'confirming',
+    'fixture-access-key-hash-1',
+    '{"newRecords":1}'::JSONB
+  );
+
+  SELECT public.commit_official_import_records(
+    '00000000-0000-0000-0000-000000000101',
+    v_user_id,
+    jsonb_build_array(jsonb_build_object(
+      'pool_id', 'rpc_pool',
+      'name', 'RPC fixture pool',
+      'type', 'limited'
+    )),
+    jsonb_build_array(jsonb_build_object(
+      'record_id', 'rpc-record-1',
+      'pool_id', 'rpc_pool',
+      'seq_id', 'rpc-seq-1',
+      'game_uid', 'rpc-game-1',
+      'nick_name', 'RPC fixture user',
+      'rarity', 6,
+      'character_name', 'RPC fixture character',
+      'item_name', 'RPC fixture character',
+      'character_id', 'rpc-character-1',
+      'timestamp', '2026-08-03T12:00:00.000Z',
+      'pity', 99,
+      'is_free', TRUE,
+      'is_info_book', TRUE,
+      'is_new', TRUE,
+      'is_standard', FALSE,
+      'server_id', '1',
+      'region', 'cn',
+      'batch_id', 'rpc-batch-1',
+      'special_type', 'guaranteed'
+    ))
+  ) INTO v_result;
+
+  IF (v_result ->> 'savedRecords')::INTEGER <> 1
+    OR (v_result ->> 'atomicCommit')::BOOLEAN IS NOT TRUE
+  THEN
+    RAISE EXCEPTION 'official_import_fixture_first_commit_failed: %', v_result;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.history
+    WHERE user_id = v_user_id
+      AND game_uid = 'rpc-game-1'
+      AND server_scope = '1'
+      AND pool_id = 'rpc_pool'
+      AND seq_id = 'rpc-seq-1'
+      AND record_id = 'rpc-record-1'
+      AND nick_name = 'RPC fixture user'
+      AND character_name = 'RPC fixture character'
+      AND character_id = 'rpc-character-1'
+      AND pity = 80
+      AND is_free IS TRUE
+      AND is_info_book IS TRUE
+      AND is_new IS TRUE
+      AND region = 'cn'
+      AND batch_id = 'rpc-batch-1'
+      AND special_type = 'guaranteed'
+  ) THEN
+    RAISE EXCEPTION 'official_import_fixture_full_payload_missing';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.official_import_tasks
+    WHERE id = '00000000-0000-0000-0000-000000000101'
+      AND status = 'committed'
+      AND committed_at IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'official_import_fixture_task_not_committed';
+  END IF;
+
+  INSERT INTO public.official_import_tasks (
+    id,
+    user_id,
+    source,
+    import_mode,
+    game_uid,
+    server_id,
+    status,
+    access_key_hash,
+    summary
+  ) VALUES (
+    '00000000-0000-0000-0000-000000000102',
+    v_user_id,
+    'cn',
+    'incremental',
+    'rpc-game-1',
+    '1',
+    'confirming',
+    'fixture-access-key-hash-2',
+    '{"newRecords":1}'::JSONB
+  );
+
+  PERFORM public.commit_official_import_records(
+    '00000000-0000-0000-0000-000000000102',
+    v_user_id,
+    '[]'::JSONB,
+    jsonb_build_array(jsonb_build_object(
+      'record_id', 'rpc-record-2',
+      'pool_id', 'rpc_pool',
+      'seq_id', 'rpc-seq-1',
+      'game_uid', 'rpc-game-1',
+      'nick_name', 'RPC fixture updated',
+      'rarity', 5,
+      'character_name', 'RPC fixture updated character',
+      'item_name', 'RPC fixture updated character',
+      'character_id', 'rpc-character-2',
+      'timestamp', '2026-08-03T12:01:00.000Z',
+      'pity', 7,
+      'is_free', FALSE,
+      'is_info_book', FALSE,
+      'is_new', FALSE,
+      'is_standard', TRUE,
+      'server_id', '1',
+      'region', 'cn',
+      'batch_id', 'rpc-batch-2',
+      'special_type', 'gift'
+    ))
+  );
+
+  IF (SELECT COUNT(*) FROM public.history
+      WHERE user_id = v_user_id
+        AND game_uid = 'rpc-game-1'
+        AND server_scope = '1'
+        AND pool_id = 'rpc_pool'
+        AND seq_id = 'rpc-seq-1') <> 1
+  THEN
+    RAISE EXCEPTION 'official_import_fixture_conflict_created_duplicate';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.history
+    WHERE user_id = v_user_id
+      AND game_uid = 'rpc-game-1'
+      AND server_scope = '1'
+      AND pool_id = 'rpc_pool'
+      AND seq_id = 'rpc-seq-1'
+      AND record_id = 'rpc-record-2'
+      AND nick_name = 'RPC fixture updated'
+      AND character_name = 'RPC fixture updated character'
+      AND character_id = 'rpc-character-2'
+      AND pity = 7
+      AND is_standard IS TRUE
+      AND batch_id = 'rpc-batch-2'
+      AND special_type = 'gift'
+  ) THEN
+    RAISE EXCEPTION 'official_import_fixture_conflict_update_incomplete';
+  END IF;
+
+  IF has_function_privilege(
+    'anon',
+    'public.commit_official_import_records(uuid,uuid,jsonb,jsonb)',
+    'EXECUTE'
+  ) OR has_function_privilege(
+    'authenticated',
+    'public.commit_official_import_records(uuid,uuid,jsonb,jsonb)',
+    'EXECUTE'
+  ) OR NOT has_function_privilege(
+    'service_role',
+    'public.commit_official_import_records(uuid,uuid,jsonb,jsonb)',
+    'EXECUTE'
+  ) THEN
+    RAISE EXCEPTION 'official_import_fixture_function_privileges_invalid';
+  END IF;
+END;
+$fixture$;
+
+SELECT 'official_import_rpc=ok';
+`.trim();
+}
+
 async function main() {
   const baselineSql = await readFile(baselinePath, 'utf8');
 
@@ -269,6 +469,18 @@ async function main() {
       ['exec', '-i', containerName, 'psql', '-v', 'ON_ERROR_STOP=1', '-U', 'postgres', '-d', databaseName],
       { input: `${buildTargetIntervalFixtureSql()}\n` }
     );
+
+    const officialImportVerification = await run(
+      'docker',
+      ['exec', '-i', containerName, 'psql', '-v', 'ON_ERROR_STOP=1', '-U', 'postgres', '-d', databaseName, '-At'],
+      { input: `${buildOfficialImportCommitFixtureSql()}\n` }
+    );
+
+    if (!officialImportVerification.stdout.includes('official_import_rpc=ok')) {
+      throw new Error(
+        `Official import RPC verification returned incomplete output:\n${officialImportVerification.stdout}`
+      );
+    }
 
     const verification = await run(
       'docker',

--- a/supabase/baseline/000_complete_schema.sql
+++ b/supabase/baseline/000_complete_schema.sql
@@ -5,8 +5,8 @@
 --   1. 此文件由 scripts/generate-supabase-baseline.mjs 自动生成
 --   2. 合并 supabase/archive/migrations/ 与 supabase/migrations/ 中的标准前向迁移
 --   3. 不包含 supabase/manual/ 下的 destructive / rollback / data-backfill 脚本
---   4. 生成时间: 2026-08-03T11:38:18.543Z
---   5. 覆盖范围: archive/001_init_tables.sql -> active/169_add_oauth_email_artifact_merge.sql
+--   4. 生成时间: 2026-08-03T14:09:02.721Z
+--   5. 覆盖范围: archive/001_init_tables.sql -> active/170_restore_official_import_atomic_commit.sql
 -- ============================================
 
 -- >>> BEGIN MIGRATION: archive/001_init_tables.sql
@@ -28400,4 +28400,289 @@ COMMENT ON FUNCTION public.inspect_oauth_email_artifact_merge(UUID, TEXT, BOOLEA
 
 NOTIFY pgrst, 'reload schema';
 -- <<< END MIGRATION: active/169_add_oauth_email_artifact_merge.sql
+
+-- >>> BEGIN MIGRATION: active/170_restore_official_import_atomic_commit.sql
+-- 170: restore the complete official-import commit after migration 168
+-- replaced it with a stale conflict target and a reduced history payload.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint AS constraint_row
+    WHERE constraint_row.conrelid = 'public.history'::REGCLASS
+      AND constraint_row.contype IN ('p', 'u')
+      AND (
+        SELECT array_agg(attribute.attname::TEXT ORDER BY key_column.ordinality)
+        FROM unnest(constraint_row.conkey) WITH ORDINALITY AS key_column(attnum, ordinality)
+        JOIN pg_attribute AS attribute
+          ON attribute.attrelid = constraint_row.conrelid
+         AND attribute.attnum = key_column.attnum
+      ) = ARRAY['user_id', 'game_uid', 'server_scope', 'pool_id', 'seq_id']::TEXT[]
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '55000',
+      MESSAGE = 'official_import_history_conflict_constraint_missing';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.commit_official_import_records(
+  p_task_id UUID,
+  p_user_id UUID,
+  p_pools JSONB,
+  p_history JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_task public.official_import_tasks%ROWTYPE;
+  v_pools JSONB := COALESCE(p_pools, '[]'::JSONB);
+  v_history JSONB := COALESCE(p_history, '[]'::JSONB);
+  v_pool_count INTEGER := 0;
+  v_history_count INTEGER := 0;
+  v_expected_count INTEGER := 0;
+  v_result JSONB;
+BEGIN
+  IF jsonb_typeof(v_pools) <> 'array' OR jsonb_typeof(v_history) <> 'array' THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'official_import_payload_must_be_arrays';
+  END IF;
+
+  SELECT *
+  INTO v_task
+  FROM public.official_import_tasks
+  WHERE id = p_task_id
+    AND user_id = p_user_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION USING ERRCODE = 'P0002', MESSAGE = 'official_import_task_not_found';
+  END IF;
+  IF v_task.status = 'committed' THEN
+    RETURN COALESCE(v_task.summary -> 'commitResult', '{}'::JSONB);
+  END IF;
+  IF v_task.status <> 'confirming' THEN
+    RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'official_import_task_not_confirming';
+  END IF;
+
+  IF NOT public.is_account_credential_allowed(p_user_id) THEN
+    RAISE EXCEPTION USING ERRCODE = '28000', MESSAGE = 'temporary_password_expired';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_to_recordset(v_history) AS item(
+      record_id TEXT,
+      pool_id TEXT,
+      seq_id TEXT,
+      game_uid TEXT,
+      rarity INTEGER,
+      timestamp TIMESTAMPTZ
+    )
+    WHERE NULLIF(btrim(item.record_id), '') IS NULL
+      OR NULLIF(btrim(item.pool_id), '') IS NULL
+      OR NULLIF(btrim(item.seq_id), '') IS NULL
+      OR NULLIF(btrim(item.game_uid), '') IS NULL
+      OR item.rarity IS NULL
+      OR item.rarity NOT BETWEEN 3 AND 6
+      OR item.timestamp IS NULL
+  ) THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'official_import_history_record_invalid';
+  END IF;
+
+  INSERT INTO public.pools (
+    user_id,
+    pool_id,
+    name,
+    type,
+    start_time,
+    end_time,
+    up_character,
+    featured_characters,
+    created_at,
+    updated_at
+  )
+  SELECT
+    p_user_id,
+    item.pool_id,
+    COALESCE(NULLIF(btrim(item.name), ''), item.pool_id),
+    item.type,
+    item.start_time,
+    item.end_time,
+    NULLIF(btrim(item.up_character), ''),
+    item.featured_characters,
+    COALESCE(item.created_at, NOW()),
+    NOW()
+  FROM jsonb_to_recordset(v_pools) AS item(
+    pool_id TEXT,
+    name TEXT,
+    type TEXT,
+    start_time TIMESTAMPTZ,
+    end_time TIMESTAMPTZ,
+    up_character TEXT,
+    featured_characters TEXT[],
+    created_at TIMESTAMPTZ
+  )
+  WHERE NULLIF(btrim(item.pool_id), '') IS NOT NULL
+    AND NULLIF(btrim(item.type), '') IS NOT NULL
+  ON CONFLICT (pool_id) DO NOTHING;
+  GET DIAGNOSTICS v_pool_count = ROW_COUNT;
+
+  INSERT INTO public.history (
+    user_id,
+    record_id,
+    pool_id,
+    seq_id,
+    game_uid,
+    nick_name,
+    rarity,
+    character_name,
+    item_name,
+    character_id,
+    timestamp,
+    pity,
+    is_free,
+    is_info_book,
+    is_new,
+    is_standard,
+    server_id,
+    region,
+    batch_id,
+    special_type,
+    created_at,
+    updated_at
+  )
+  SELECT
+    p_user_id,
+    item.record_id,
+    item.pool_id,
+    item.seq_id,
+    item.game_uid,
+    item.nick_name,
+    item.rarity,
+    item.character_name,
+    item.item_name,
+    item.character_id,
+    item.timestamp,
+    LEAST(GREATEST(COALESCE(item.pity, 0), 0), 80),
+    COALESCE(item.is_free, FALSE),
+    COALESCE(item.is_info_book, FALSE),
+    COALESCE(item.is_new, FALSE),
+    COALESCE(item.is_standard, FALSE),
+    item.server_id,
+    item.region,
+    item.batch_id,
+    item.special_type,
+    COALESCE(item.created_at, NOW()),
+    NOW()
+  FROM jsonb_to_recordset(v_history) AS item(
+    record_id TEXT,
+    pool_id TEXT,
+    seq_id TEXT,
+    game_uid TEXT,
+    nick_name TEXT,
+    rarity INTEGER,
+    character_name TEXT,
+    item_name TEXT,
+    character_id TEXT,
+    timestamp TIMESTAMPTZ,
+    pity INTEGER,
+    is_free BOOLEAN,
+    is_info_book BOOLEAN,
+    is_new BOOLEAN,
+    is_standard BOOLEAN,
+    server_id TEXT,
+    region TEXT,
+    batch_id TEXT,
+    special_type TEXT,
+    created_at TIMESTAMPTZ
+  )
+  ON CONFLICT (user_id, game_uid, server_scope, pool_id, seq_id)
+  DO UPDATE SET
+    record_id = EXCLUDED.record_id,
+    nick_name = EXCLUDED.nick_name,
+    rarity = EXCLUDED.rarity,
+    character_name = EXCLUDED.character_name,
+    item_name = EXCLUDED.item_name,
+    character_id = EXCLUDED.character_id,
+    timestamp = EXCLUDED.timestamp,
+    pity = EXCLUDED.pity,
+    is_free = EXCLUDED.is_free,
+    is_info_book = EXCLUDED.is_info_book,
+    is_new = EXCLUDED.is_new,
+    is_standard = EXCLUDED.is_standard,
+    server_id = EXCLUDED.server_id,
+    region = EXCLUDED.region,
+    batch_id = EXCLUDED.batch_id,
+    special_type = EXCLUDED.special_type,
+    updated_at = NOW();
+  GET DIAGNOSTICS v_history_count = ROW_COUNT;
+
+  v_expected_count := COALESCE((v_task.summary ->> 'newRecords')::INTEGER, v_history_count);
+  v_result := jsonb_build_object(
+    'savedRecords', v_history_count,
+    'skippedRecords', GREATEST(v_expected_count - v_history_count, 0),
+    'createdPools', v_pool_count,
+    'atomicCommit', TRUE
+  );
+
+  UPDATE public.official_import_tasks
+  SET
+    status = 'committed',
+    summary = COALESCE(summary, '{}'::JSONB) || jsonb_build_object('commitResult', v_result),
+    committed_at = NOW(),
+    updated_at = NOW()
+  WHERE id = p_task_id
+    AND user_id = p_user_id
+    AND status = 'confirming';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION USING ERRCODE = '40001', MESSAGE = 'official_import_task_state_changed';
+  END IF;
+
+  RETURN v_result;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.commit_official_import_records(UUID, UUID, JSONB, JSONB)
+  FROM PUBLIC, anon, authenticated;
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+    GRANT EXECUTE ON FUNCTION public.commit_official_import_records(UUID, UUID, JSONB, JSONB)
+      TO service_role;
+  END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION public.commit_official_import_records(UUID, UUID, JSONB, JSONB) IS
+  '确认官方导入时，在一笔事务中校验凭据、写入完整卡池与历史，并提交审阅任务。';
+
+DO $$
+DECLARE
+  v_definition TEXT;
+BEGIN
+  v_definition := pg_get_functiondef(
+    'public.commit_official_import_records(uuid,uuid,jsonb,jsonb)'::REGPROCEDURE
+  );
+
+  IF v_definition !~* 'ON CONFLICT\s*\(\s*user_id\s*,\s*game_uid\s*,\s*server_scope\s*,\s*pool_id\s*,\s*seq_id\s*\)' THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '55000',
+      MESSAGE = 'official_import_history_conflict_target_invalid';
+  END IF;
+
+  IF v_definition ~* 'ON CONFLICT\s*\(\s*user_id\s*,\s*game_uid\s*,\s*server_id\s*,' THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '55000',
+      MESSAGE = 'official_import_legacy_conflict_target_present';
+  END IF;
+END;
+$$;
+
+NOTIFY pgrst, 'reload schema';
+-- <<< END MIGRATION: active/170_restore_official_import_atomic_commit.sql
 

--- a/supabase/manual/data-backfill/170_backfill_missing_official_import_anomalies.sql
+++ b/supabase/manual/data-backfill/170_backfill_missing_official_import_anomalies.sql
@@ -1,0 +1,105 @@
+-- 170 production repair: restore review markers that were lost when one
+-- invalid child key caused a whole history_anomalies upsert batch to fail.
+--
+-- This is intentionally a guarded, one-time data repair and is excluded from
+-- the generated baseline. It inserts from the existing history parent rows so
+-- every composite foreign key is guaranteed to match.
+
+DO $$
+DECLARE
+  v_candidate_count INTEGER;
+  v_inserted_count INTEGER;
+BEGIN
+  SELECT COUNT(*)
+  INTO v_candidate_count
+  FROM public.history AS history_row
+  LEFT JOIN public.history_anomalies AS anomaly
+    ON anomaly.user_id = history_row.user_id
+   AND anomaly.game_uid = history_row.game_uid
+   AND anomaly.server_scope = history_row.server_scope
+   AND anomaly.pool_id = history_row.pool_id
+   AND anomaly.seq_id = history_row.seq_id
+   AND anomaly.issue_code = 'OFFICIAL_IMPORT_UNKNOWN_ITEM'
+  WHERE anomaly.id IS NULL
+    AND NULLIF(btrim(history_row.character_id), '') IS NULL
+    AND NULLIF(btrim(history_row.item_name), '') IS NULL
+    AND history_row.rarity = 4
+    AND history_row.special_type IS NULL;
+
+  IF v_candidate_count <> 10 THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '55000',
+      MESSAGE = FORMAT(
+        'official_import_anomaly_backfill_snapshot_mismatch: expected=10 actual=%s',
+        v_candidate_count
+      );
+  END IF;
+
+  WITH inserted AS (
+    INSERT INTO public.history_anomalies (
+      user_id,
+      record_id,
+      game_uid,
+      server_scope,
+      pool_id,
+      seq_id,
+      issue_code,
+      status,
+      details
+    )
+    SELECT
+      history_row.user_id,
+      history_row.record_id,
+      history_row.game_uid,
+      history_row.server_scope,
+      history_row.pool_id,
+      history_row.seq_id,
+      'OFFICIAL_IMPORT_UNKNOWN_ITEM',
+      'pending',
+      jsonb_strip_nulls(jsonb_build_object(
+        'message', '本次官方导入没有完整识别这条记录的角色或武器，请确认它是否正确。',
+        'itemName', COALESCE(
+          NULLIF(btrim(history_row.item_name), ''),
+          NULLIF(btrim(history_row.character_name), ''),
+          '未知角色或武器'
+        ),
+        'rarity', history_row.rarity,
+        'timestamp', history_row.timestamp,
+        'pity', history_row.pity,
+        'serverId', history_row.server_id,
+        'region', history_row.region,
+        'issueCodes', jsonb_build_array('MISSING_ITEM_ID_AND_NAME'),
+        'repairSource', 'production_repair_2026_08_03'
+      ))
+    FROM public.history AS history_row
+    LEFT JOIN public.history_anomalies AS anomaly
+      ON anomaly.user_id = history_row.user_id
+     AND anomaly.game_uid = history_row.game_uid
+     AND anomaly.server_scope = history_row.server_scope
+     AND anomaly.pool_id = history_row.pool_id
+     AND anomaly.seq_id = history_row.seq_id
+     AND anomaly.issue_code = 'OFFICIAL_IMPORT_UNKNOWN_ITEM'
+    WHERE anomaly.id IS NULL
+      AND NULLIF(btrim(history_row.character_id), '') IS NULL
+      AND NULLIF(btrim(history_row.item_name), '') IS NULL
+      AND history_row.rarity = 4
+      AND history_row.special_type IS NULL
+    ON CONFLICT (user_id, game_uid, server_scope, pool_id, seq_id, issue_code)
+      DO NOTHING
+    RETURNING 1
+  )
+  SELECT COUNT(*)
+  INTO v_inserted_count
+  FROM inserted;
+
+  IF v_inserted_count <> v_candidate_count THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '40001',
+      MESSAGE = FORMAT(
+        'official_import_anomaly_backfill_write_mismatch: expected=%s actual=%s',
+        v_candidate_count,
+        v_inserted_count
+      );
+  END IF;
+END;
+$$;

--- a/supabase/migrations/170_restore_official_import_atomic_commit.sql
+++ b/supabase/migrations/170_restore_official_import_atomic_commit.sql
@@ -1,0 +1,282 @@
+-- 170: restore the complete official-import commit after migration 168
+-- replaced it with a stale conflict target and a reduced history payload.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint AS constraint_row
+    WHERE constraint_row.conrelid = 'public.history'::REGCLASS
+      AND constraint_row.contype IN ('p', 'u')
+      AND (
+        SELECT array_agg(attribute.attname::TEXT ORDER BY key_column.ordinality)
+        FROM unnest(constraint_row.conkey) WITH ORDINALITY AS key_column(attnum, ordinality)
+        JOIN pg_attribute AS attribute
+          ON attribute.attrelid = constraint_row.conrelid
+         AND attribute.attnum = key_column.attnum
+      ) = ARRAY['user_id', 'game_uid', 'server_scope', 'pool_id', 'seq_id']::TEXT[]
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '55000',
+      MESSAGE = 'official_import_history_conflict_constraint_missing';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.commit_official_import_records(
+  p_task_id UUID,
+  p_user_id UUID,
+  p_pools JSONB,
+  p_history JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_task public.official_import_tasks%ROWTYPE;
+  v_pools JSONB := COALESCE(p_pools, '[]'::JSONB);
+  v_history JSONB := COALESCE(p_history, '[]'::JSONB);
+  v_pool_count INTEGER := 0;
+  v_history_count INTEGER := 0;
+  v_expected_count INTEGER := 0;
+  v_result JSONB;
+BEGIN
+  IF jsonb_typeof(v_pools) <> 'array' OR jsonb_typeof(v_history) <> 'array' THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'official_import_payload_must_be_arrays';
+  END IF;
+
+  SELECT *
+  INTO v_task
+  FROM public.official_import_tasks
+  WHERE id = p_task_id
+    AND user_id = p_user_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION USING ERRCODE = 'P0002', MESSAGE = 'official_import_task_not_found';
+  END IF;
+  IF v_task.status = 'committed' THEN
+    RETURN COALESCE(v_task.summary -> 'commitResult', '{}'::JSONB);
+  END IF;
+  IF v_task.status <> 'confirming' THEN
+    RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'official_import_task_not_confirming';
+  END IF;
+
+  IF NOT public.is_account_credential_allowed(p_user_id) THEN
+    RAISE EXCEPTION USING ERRCODE = '28000', MESSAGE = 'temporary_password_expired';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_to_recordset(v_history) AS item(
+      record_id TEXT,
+      pool_id TEXT,
+      seq_id TEXT,
+      game_uid TEXT,
+      rarity INTEGER,
+      timestamp TIMESTAMPTZ
+    )
+    WHERE NULLIF(btrim(item.record_id), '') IS NULL
+      OR NULLIF(btrim(item.pool_id), '') IS NULL
+      OR NULLIF(btrim(item.seq_id), '') IS NULL
+      OR NULLIF(btrim(item.game_uid), '') IS NULL
+      OR item.rarity IS NULL
+      OR item.rarity NOT BETWEEN 3 AND 6
+      OR item.timestamp IS NULL
+  ) THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'official_import_history_record_invalid';
+  END IF;
+
+  INSERT INTO public.pools (
+    user_id,
+    pool_id,
+    name,
+    type,
+    start_time,
+    end_time,
+    up_character,
+    featured_characters,
+    created_at,
+    updated_at
+  )
+  SELECT
+    p_user_id,
+    item.pool_id,
+    COALESCE(NULLIF(btrim(item.name), ''), item.pool_id),
+    item.type,
+    item.start_time,
+    item.end_time,
+    NULLIF(btrim(item.up_character), ''),
+    item.featured_characters,
+    COALESCE(item.created_at, NOW()),
+    NOW()
+  FROM jsonb_to_recordset(v_pools) AS item(
+    pool_id TEXT,
+    name TEXT,
+    type TEXT,
+    start_time TIMESTAMPTZ,
+    end_time TIMESTAMPTZ,
+    up_character TEXT,
+    featured_characters TEXT[],
+    created_at TIMESTAMPTZ
+  )
+  WHERE NULLIF(btrim(item.pool_id), '') IS NOT NULL
+    AND NULLIF(btrim(item.type), '') IS NOT NULL
+  ON CONFLICT (pool_id) DO NOTHING;
+  GET DIAGNOSTICS v_pool_count = ROW_COUNT;
+
+  INSERT INTO public.history (
+    user_id,
+    record_id,
+    pool_id,
+    seq_id,
+    game_uid,
+    nick_name,
+    rarity,
+    character_name,
+    item_name,
+    character_id,
+    timestamp,
+    pity,
+    is_free,
+    is_info_book,
+    is_new,
+    is_standard,
+    server_id,
+    region,
+    batch_id,
+    special_type,
+    created_at,
+    updated_at
+  )
+  SELECT
+    p_user_id,
+    item.record_id,
+    item.pool_id,
+    item.seq_id,
+    item.game_uid,
+    item.nick_name,
+    item.rarity,
+    item.character_name,
+    item.item_name,
+    item.character_id,
+    item.timestamp,
+    LEAST(GREATEST(COALESCE(item.pity, 0), 0), 80),
+    COALESCE(item.is_free, FALSE),
+    COALESCE(item.is_info_book, FALSE),
+    COALESCE(item.is_new, FALSE),
+    COALESCE(item.is_standard, FALSE),
+    item.server_id,
+    item.region,
+    item.batch_id,
+    item.special_type,
+    COALESCE(item.created_at, NOW()),
+    NOW()
+  FROM jsonb_to_recordset(v_history) AS item(
+    record_id TEXT,
+    pool_id TEXT,
+    seq_id TEXT,
+    game_uid TEXT,
+    nick_name TEXT,
+    rarity INTEGER,
+    character_name TEXT,
+    item_name TEXT,
+    character_id TEXT,
+    timestamp TIMESTAMPTZ,
+    pity INTEGER,
+    is_free BOOLEAN,
+    is_info_book BOOLEAN,
+    is_new BOOLEAN,
+    is_standard BOOLEAN,
+    server_id TEXT,
+    region TEXT,
+    batch_id TEXT,
+    special_type TEXT,
+    created_at TIMESTAMPTZ
+  )
+  ON CONFLICT (user_id, game_uid, server_scope, pool_id, seq_id)
+  DO UPDATE SET
+    record_id = EXCLUDED.record_id,
+    nick_name = EXCLUDED.nick_name,
+    rarity = EXCLUDED.rarity,
+    character_name = EXCLUDED.character_name,
+    item_name = EXCLUDED.item_name,
+    character_id = EXCLUDED.character_id,
+    timestamp = EXCLUDED.timestamp,
+    pity = EXCLUDED.pity,
+    is_free = EXCLUDED.is_free,
+    is_info_book = EXCLUDED.is_info_book,
+    is_new = EXCLUDED.is_new,
+    is_standard = EXCLUDED.is_standard,
+    server_id = EXCLUDED.server_id,
+    region = EXCLUDED.region,
+    batch_id = EXCLUDED.batch_id,
+    special_type = EXCLUDED.special_type,
+    updated_at = NOW();
+  GET DIAGNOSTICS v_history_count = ROW_COUNT;
+
+  v_expected_count := COALESCE((v_task.summary ->> 'newRecords')::INTEGER, v_history_count);
+  v_result := jsonb_build_object(
+    'savedRecords', v_history_count,
+    'skippedRecords', GREATEST(v_expected_count - v_history_count, 0),
+    'createdPools', v_pool_count,
+    'atomicCommit', TRUE
+  );
+
+  UPDATE public.official_import_tasks
+  SET
+    status = 'committed',
+    summary = COALESCE(summary, '{}'::JSONB) || jsonb_build_object('commitResult', v_result),
+    committed_at = NOW(),
+    updated_at = NOW()
+  WHERE id = p_task_id
+    AND user_id = p_user_id
+    AND status = 'confirming';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION USING ERRCODE = '40001', MESSAGE = 'official_import_task_state_changed';
+  END IF;
+
+  RETURN v_result;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.commit_official_import_records(UUID, UUID, JSONB, JSONB)
+  FROM PUBLIC, anon, authenticated;
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+    GRANT EXECUTE ON FUNCTION public.commit_official_import_records(UUID, UUID, JSONB, JSONB)
+      TO service_role;
+  END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION public.commit_official_import_records(UUID, UUID, JSONB, JSONB) IS
+  '确认官方导入时，在一笔事务中校验凭据、写入完整卡池与历史，并提交审阅任务。';
+
+DO $$
+DECLARE
+  v_definition TEXT;
+BEGIN
+  v_definition := pg_get_functiondef(
+    'public.commit_official_import_records(uuid,uuid,jsonb,jsonb)'::REGPROCEDURE
+  );
+
+  IF v_definition !~* 'ON CONFLICT\s*\(\s*user_id\s*,\s*game_uid\s*,\s*server_scope\s*,\s*pool_id\s*,\s*seq_id\s*\)' THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '55000',
+      MESSAGE = 'official_import_history_conflict_target_invalid';
+  END IF;
+
+  IF v_definition ~* 'ON CONFLICT\s*\(\s*user_id\s*,\s*game_uid\s*,\s*server_id\s*,' THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '55000',
+      MESSAGE = 'official_import_legacy_conflict_target_present';
+  END IF;
+END;
+$$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

- 恢复 `commit_official_import_records` 的完整原子写入，并将冲突目标重新对齐 `server_scope` 唯一键，同时保留迁移 168 的凭据到期检查和最小执行权限
- 增加受控数据回填，补齐历史上因复合外键失败丢失的 10 条未知物品核对提醒
- 隔离单条无父记录的异常提醒，避免一个坏键拖垮整批；补充 PostgreSQL 17 真实执行和静态回归保护

## Production status

- 共享生产数据库已在完整备份和 SHA-256 校验后单事务应用迁移 170
- CN / INTL 修复后新增 `42P10` 为 0，两个 1.6.3 容器均 healthy、队列为空、重启数为 0
- 10 条缺失提醒已回填，剩余目标候选和外键孤儿均为 0
- 私有后端源码与主线存在 79 行认证差异，本 PR 的异常提醒批次隔离逻辑尚未部署到私有后端

## Test plan

- [x] PostgreSQL 17 从完整 161 迁移构建空库
- [x] 验证首次原子写入、同区服冲突更新、完整字段、任务提交和 RPC 权限
- [x] Node 24：`fullImportService.test.js` 与 `historyReviewMigrations.test.js`，35 项通过
- [x] `verify-supabase-baseline.mjs`
- [x] `git diff --check`
- [x] CN / INTL service-role RPC 可见性、容器健康、队列和修复后日志核验