### PR TITLE
fix: 原子隔离 OAuth 邮箱空壳

### DIFF
--- a/api/__tests__/oauthEmailArtifactMerge.test.js
+++ b/api/__tests__/oauthEmailArtifactMerge.test.js
@@ -27,7 +27,11 @@ const ARTIFACT_ID = '00000000-0000-4000-8000-000000000002';
 const INTENT_ID = '10000000-0000-4000-8000-000000000001';
 const SESSION_ID = '50000000-0000-4000-8000-000000000001';
 
-function createAdminClient({ failSourceBinding = false } = {}) {
+function createAdminClient({
+  failQuarantine = false,
+  quarantineCommitThenError = false,
+  failSourceBinding = false,
+} = {}) {
   const intent = {
     id: INTENT_ID,
     source_user_id: SOURCE_ID,
@@ -52,9 +56,29 @@ function createAdminClient({ failSourceBinding = false } = {}) {
       user_metadata: { email_verified: true },
     },
   };
+  let quarantineAttempts = 0;
   const rpc = vi.fn(async (name) => {
     if (name === 'claim_oauth_email_artifact_merge') {
       intent.status = 'claimed';
+      return { data: [{ ...intent }], error: null };
+    }
+    if (name === 'quarantine_oauth_email_artifact_for_merge') {
+      quarantineAttempts += 1;
+      if (failQuarantine) {
+        return { data: null, error: { code: 'quarantine_failed' } };
+      }
+      users[ARTIFACT_ID] = {
+        ...users[ARTIFACT_ID],
+        email: intent.quarantine_email,
+        user_metadata: {
+          ...users[ARTIFACT_ID].user_metadata,
+          legacy_email_action_artifact: true,
+          oauth_email_merge_intent_id: intent.id,
+        },
+      };
+      if (quarantineCommitThenError && quarantineAttempts === 1) {
+        return { data: null, error: { code: 'network_response_lost' } };
+      }
       return { data: [{ ...intent }], error: null };
     }
     if (name === 'prepare_oauth_email_artifact_ownership_transfer') {
@@ -74,6 +98,7 @@ function createAdminClient({ failSourceBinding = false } = {}) {
       return { data: [{ ...intent }], error: null };
     }
     if (name === 'mark_oauth_email_artifact_merge_coordination_required') {
+      intent.status = 'coordination_required';
       return { data: null, error: null };
     }
     throw new Error(`Unexpected RPC: ${name}`);
@@ -210,6 +235,7 @@ describe('OAuth email artifact merge helpers', () => {
     });
     expect(context.rpc.mock.calls.map(([name]) => name)).toEqual([
       'claim_oauth_email_artifact_merge',
+      'quarantine_oauth_email_artifact_for_merge',
       'prepare_oauth_email_artifact_ownership_transfer',
       'complete_oauth_email_artifact_merge',
     ]);
@@ -248,10 +274,67 @@ describe('OAuth email artifact merge helpers', () => {
     });
     expect(context.rpc.mock.calls.map(([name]) => name)).toEqual([
       'claim_oauth_email_artifact_merge',
+      'quarantine_oauth_email_artifact_for_merge',
       'prepare_oauth_email_artifact_ownership_transfer',
       'rollback_oauth_email_artifact_ownership_transfer',
     ]);
     expect(mocks.createSiteSession).not.toHaveBeenCalled();
+  });
+
+  it('keeps a failed atomic quarantine fail-closed for operator coordination', async () => {
+    const context = createAdminClient({ failQuarantine: true });
+    mocks.loadAuthUserById.mockImplementation(async (_client, userId) => context.users[userId]);
+
+    const result = await completeOAuthEmailArtifactMerge(context.adminClient, {
+      intentId: INTENT_ID,
+      sourceUserId: SOURCE_ID,
+      startedSessionId: SESSION_ID,
+      req: { headers: {} },
+      res: { setHeader: vi.fn() },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      code: 'oauth_email_merge_coordination_required',
+    });
+    expect(context.intent.status).toBe('coordination_required');
+    expect(context.users[ARTIFACT_ID]).toMatchObject({
+      email: 'legacy@example.com',
+      user_metadata: { email_verified: true },
+    });
+    expect(context.updateUserById).not.toHaveBeenCalledWith(
+      ARTIFACT_ID,
+      expect.anything()
+    );
+    expect(context.rpc.mock.calls.map(([name]) => name)).toEqual([
+      'claim_oauth_email_artifact_merge',
+      'quarantine_oauth_email_artifact_for_merge',
+      'quarantine_oauth_email_artifact_for_merge',
+      'mark_oauth_email_artifact_merge_coordination_required',
+    ]);
+    expect(mocks.createSiteSession).not.toHaveBeenCalled();
+  });
+
+  it('retries an idempotent quarantine after the commit response is lost', async () => {
+    const context = createAdminClient({ quarantineCommitThenError: true });
+    mocks.loadAuthUserById.mockImplementation(async (_client, userId) => context.users[userId]);
+
+    const result = await completeOAuthEmailArtifactMerge(context.adminClient, {
+      intentId: INTENT_ID,
+      sourceUserId: SOURCE_ID,
+      startedSessionId: SESSION_ID,
+      req: { headers: {} },
+      res: { setHeader: vi.fn() },
+    });
+
+    expect(result).toMatchObject({ ok: true, status: 'completed' });
+    expect(context.rpc.mock.calls.map(([name]) => name)).toEqual([
+      'claim_oauth_email_artifact_merge',
+      'quarantine_oauth_email_artifact_for_merge',
+      'quarantine_oauth_email_artifact_for_merge',
+      'prepare_oauth_email_artifact_ownership_transfer',
+      'complete_oauth_email_artifact_merge',
+    ]);
   });
 
   it('requires the original site session to claim a verified intent', async () => {

--- a/api/_lib/oauthEmailArtifactMerge.js
+++ b/api/_lib/oauthEmailArtifactMerge.js
@@ -4,7 +4,6 @@ import { loadAuthUserById } from './authAdmin.js';
 import { createSiteSession } from './siteSession.js';
 
 const SYNTHETIC_OAUTH_EMAIL_SUFFIX = '@oauth.local.invalid';
-const LONG_QUARANTINE_DURATION = '876000h';
 
 function normalizeText(value) {
   return String(value || '').trim();
@@ -377,29 +376,37 @@ export async function completeOAuthEmailArtifactMerge(adminClient, {
       return { ok: false, code: 'oauth_email_merge_source_changed' };
     }
 
-    const releasedAt = new Date().toISOString();
-    const artifactRelease = await updateAuthUserAndReconcile(
-      adminClient,
-      latestIntent.artifact_user_id,
-      {
-        email: latestIntent.quarantine_email,
-        email_confirm: true,
-        ban_duration: LONG_QUARANTINE_DURATION,
-        user_metadata: {
-          ...getUserMetadata(artifactAuthUser),
-          legacy_email_action_artifact: true,
-          legacy_email_released_at: releasedAt,
-          oauth_email_merge_intent_id: latestIntent.id,
-        },
-      },
-      (user) => (
-        normalizeAccountMergeEmail(user?.email) === latestIntent.quarantine_email
-        && getUserMetadata(user).oauth_email_merge_intent_id === latestIntent.id
-      )
-    );
-    if (!artifactRelease.ok) {
-      await releaseClaimAndRestoreArtifact(adminClient, latestIntent, artifactAuthUser, 'quarantine_failed');
-      return { ok: false, code: 'oauth_email_artifact_quarantine_failed' };
+    let quarantined = null;
+    let quarantineError = null;
+    for (let attempt = 0; attempt < 2 && !quarantined?.id; attempt += 1) {
+      try {
+        quarantined = await runRpc(adminClient, 'quarantine_oauth_email_artifact_for_merge', {
+          p_intent_id: latestIntent.id,
+          p_source_user_id: latestIntent.source_user_id,
+        });
+      } catch (error) {
+        quarantineError = error;
+      }
+    }
+    if (!quarantined?.id) {
+      const currentArtifact = await loadAuthUserById(
+        adminClient,
+        latestIntent.artifact_user_id
+      ).catch(() => null);
+      const reconciled = (
+        normalizeAccountMergeEmail(currentArtifact?.email) === latestIntent.quarantine_email
+        && getUserMetadata(currentArtifact).oauth_email_merge_intent_id === latestIntent.id
+      );
+      if (reconciled) {
+        quarantined = latestIntent;
+      } else {
+        await markCoordinationRequired(
+          adminClient,
+          latestIntent,
+          quarantineError?.code || 'quarantine_result_unknown'
+        );
+        return { ok: false, code: 'oauth_email_merge_coordination_required' };
+      }
     }
 
     let transferred;

--- a/docs/AUTH_SECURITY_HARDENING.md
+++ b/docs/AUTH_SECURITY_HARDENING.md
@@ -2,7 +2,9 @@
 
 > 2026-08-03 发布后更新：认证迁移 166/167/168、PR #14 和对应 API/前端已经生产完成。本文后续部分保留发布前候选审查快照；新的 `169_add_oauth_email_artifact_merge.sql` 及配套接口只处理旧版邮箱验证流程产生、且经严格证据确认没有任何站内数据的 Auth 空壳。用户必须在当前 GitHub Session 中验证目标邮箱并再次明确确认；真实已有账号、证据不全或任何数据归属冲突继续安全拒绝并转人工处理。安全复核后进一步收口：可修复判定要求 operator 逐条人工批准、验证码预算按源用户+邮箱持久累计、确认阶段在数据库内重新原子占用并冻结空壳（含双方原生 Auth Session 撤销）、按数据库最终状态决策补偿、完成后支持会话交接重试；这些都已在临时 PostgreSQL 17 与专项测试中验证。
 
-> 跟进迁移 `171_allow_consumed_magiclink_email_artifact.sql`（2026-08-04 候选，尚未生产应用）：识别旧缺陷的第二种精确形状——用户点击过旧 Magic Link、留下占位 bcrypt 密码与原生 Session/refresh token 的 email-only Auth 空壳。该形状要求独立的 operator 证据版本 `legacy_magiclink_consumed_v2`，并绑定：真实源用户、真实工单、super_admin 批准人、不可变的完整证据快照哈希（覆盖 Auth 用户、identities、sessions、refresh tokens、审计与邮件投递证据）。`service_role` 对批准表只读；claim 先锁定批准行再复核；refresh token 必须非空、未撤销、未轮换且每个 Session 恰好一条。任何自动形状检查均不把 bcrypt 外形当作 Magic Link 占位密码的唯一证明，证据快照在批准与 claim 时逐字节一致。
+> 跟进迁移 `171_allow_consumed_magiclink_email_artifact.sql`（2026-08-04 已生产应用）：识别旧缺陷的第二种精确形状——用户点击过旧 Magic Link、留下占位 bcrypt 密码与原生 Session/refresh token 的 email-only Auth 空壳。该形状要求独立的 operator 证据版本 `legacy_magiclink_consumed_v2`，并绑定：真实源用户、真实工单、super_admin 批准人、不可变的完整证据快照哈希（覆盖 Auth 用户、identities、sessions、refresh tokens、审计与邮件投递证据）。`service_role` 对批准表只读；claim 先锁定批准行再复核；refresh token 必须非空、未撤销、未轮换且每个 Session 恰好一条。任何自动形状检查均不把 bcrypt 外形当作 Magic Link 占位密码的唯一证明，证据快照在批准与 claim 时逐字节一致。
+
+> 2026-08-04 生产跟进：迁移 171 与 operator 批准已生产应用。真实确认请求暴露出 GoTrue v2.188.1 Admin 更新用户会依次修改 email identity、Auth email、metadata 与封禁状态，活动 intent 的冻结触发器因此正确拒绝中间状态。迁移 `172_quarantine_oauth_email_artifact_atomically.sql` 将空壳用户、唯一 email identity、intent metadata 与长期封禁收口为同一数据库事务，并为活动空壳 identity 增加精确冻结触发器；应用层改用该 RPC，结果不明时先幂等重试，仍无法确认则进入人工协调状态，不再错误释放 claim。专项测试同时覆盖 identity 并发新增拒绝、用户更新失败后的整笔回滚，以及 v1/v2 最终隔离不变量。
 
 状态：`AUTH-HARDEN-001` 本地安全实现与候选验收已完成；远端审查和生产发布由 `AUTH-HARDEN-RELEASE-001` 继续跟踪。本地提交不等于已发布或允许部署。
 

--- a/scripts/verify-auth-hardening-phase-cd.mjs
+++ b/scripts/verify-auth-hardening-phase-cd.mjs
@@ -84,7 +84,9 @@ CREATE TABLE auth.identities (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   provider TEXT NOT NULL,
-  identity_data JSONB DEFAULT '{}'::jsonb
+  identity_data JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 CREATE TABLE auth.sessions (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -904,14 +906,99 @@ SELECT 'oauth_email_merge_source_auth_sessions=' || COUNT(*)
 FROM auth.sessions
 WHERE user_id = '00000000-0000-4000-8000-000000000010';
 
-UPDATE auth.users
-SET
-  email = 'legacy.merge.00000000000040008000000000000011@oauth.local.invalid',
-  raw_user_meta_data = raw_user_meta_data || JSONB_BUILD_OBJECT(
-    'legacy_email_action_artifact', TRUE,
-    'oauth_email_merge_intent_id', '80000000-0000-4000-8000-000000000010'
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO auth.identities (id, user_id, provider, identity_data)
+    VALUES (
+      '40000000-0000-4000-8000-000000000099',
+      '00000000-0000-4000-8000-000000000011',
+      'github',
+      '{"email":"unexpected@example.com"}'::JSONB
+    );
+    RAISE EXCEPTION 'identity insert unexpectedly succeeded';
+  EXCEPTION WHEN object_not_in_prerequisite_state THEN NULL;
+  END;
+END $$;
+
+SELECT 'oauth_email_merge_identity_insert_blocked=' || COUNT(*)
+FROM auth.identities
+WHERE id = '40000000-0000-4000-8000-000000000099';
+
+CREATE OR REPLACE FUNCTION public.test_fail_oauth_artifact_quarantine_user_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.id = '00000000-0000-4000-8000-000000000011'
+    AND public.normalize_account_email(NEW.email) LIKE '%@oauth.local.invalid' THEN
+    RAISE EXCEPTION 'test_quarantine_user_update_failed' USING ERRCODE = 'P0001';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER aaa_test_fail_oauth_artifact_quarantine_user_update
+  BEFORE UPDATE ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.test_fail_oauth_artifact_quarantine_user_update();
+
+SET ROLE service_role;
+
+DO $$
+BEGIN
+  BEGIN
+    PERFORM *
+    FROM public.quarantine_oauth_email_artifact_for_merge(
+      '80000000-0000-4000-8000-000000000010',
+      '00000000-0000-4000-8000-000000000010'
+    );
+    RAISE EXCEPTION 'quarantine unexpectedly succeeded';
+  EXCEPTION WHEN raise_exception THEN
+    IF SQLERRM <> 'test_quarantine_user_update_failed' THEN RAISE; END IF;
+  END;
+END $$;
+
+RESET ROLE;
+
+DROP TRIGGER aaa_test_fail_oauth_artifact_quarantine_user_update ON auth.users;
+DROP FUNCTION public.test_fail_oauth_artifact_quarantine_user_update();
+
+SELECT 'oauth_email_merge_atomic_rollback=' || (
+  public.normalize_account_email(auth_user.email) = 'legacy.merge@example.com'
+  AND public.normalize_account_email(identity.identity_data ->> 'email') = 'legacy.merge@example.com'
+  AND auth_user.banned_until IS NULL
+  AND NOT (auth_user.raw_user_meta_data ? 'oauth_email_merge_intent_id')
+)
+FROM auth.users AS auth_user
+JOIN auth.identities AS identity ON identity.user_id = auth_user.id
+WHERE auth_user.id = '00000000-0000-4000-8000-000000000011';
+
+SET ROLE service_role;
+
+SELECT 'oauth_email_merge_quarantined=' || status
+FROM public.quarantine_oauth_email_artifact_for_merge(
+  '80000000-0000-4000-8000-000000000010',
+  '00000000-0000-4000-8000-000000000010'
+);
+
+RESET ROLE;
+
+SELECT 'oauth_email_merge_quarantine_state=' || (
+  public.normalize_account_email(auth_user.email) = 'legacy.merge.00000000000040008000000000000011@oauth.local.invalid'
+  AND auth_user.banned_until > NOW()
+  AND auth_user.raw_user_meta_data ->> 'oauth_email_merge_intent_id' = '80000000-0000-4000-8000-000000000010'
+  AND COUNT(identity.id) = 1
+  AND BOOL_AND(identity.provider = 'email')
+  AND BOOL_AND(
+    public.normalize_account_email(identity.identity_data ->> 'email')
+      = 'legacy.merge.00000000000040008000000000000011@oauth.local.invalid'
   )
-WHERE id = '00000000-0000-4000-8000-000000000011';
+  AND BOOL_AND(LOWER(identity.identity_data ->> 'email_verified') = 'true')
+)
+FROM auth.users AS auth_user
+JOIN auth.identities AS identity ON identity.user_id = auth_user.id
+WHERE auth_user.id = '00000000-0000-4000-8000-000000000011'
+GROUP BY auth_user.id, auth_user.email, auth_user.banned_until, auth_user.raw_user_meta_data;
 
 SET ROLE service_role;
 
@@ -1410,7 +1497,29 @@ FROM public.claim_oauth_email_artifact_merge(
   '50000000-0000-4000-8000-000000000012'
 );
 
+SELECT 'oauth_email_consumed_quarantined=' || status
+FROM public.quarantine_oauth_email_artifact_for_merge(
+  '80000000-0000-4000-8000-000000000012',
+  '00000000-0000-4000-8000-000000000012'
+);
+
 RESET ROLE;
+
+SELECT 'oauth_email_consumed_quarantine_state=' || (
+  public.normalize_account_email(auth_user.email) = 'legacy.merge.00000000000040008000000000000013@oauth.local.invalid'
+  AND auth_user.banned_until > NOW()
+  AND auth_user.raw_user_meta_data ->> 'oauth_email_merge_intent_id' = '80000000-0000-4000-8000-000000000012'
+  AND COUNT(identity.id) = 1
+  AND BOOL_AND(identity.provider = 'email')
+  AND BOOL_AND(
+    public.normalize_account_email(identity.identity_data ->> 'email')
+      = 'legacy.merge.00000000000040008000000000000013@oauth.local.invalid'
+  )
+)
+FROM auth.users AS auth_user
+JOIN auth.identities AS identity ON identity.user_id = auth_user.id
+WHERE auth_user.id = '00000000-0000-4000-8000-000000000013'
+GROUP BY auth_user.id, auth_user.email, auth_user.banned_until, auth_user.raw_user_meta_data;
 
 SELECT 'oauth_email_consumed_auth_sessions=' || COUNT(*)
 FROM auth.sessions
@@ -1490,6 +1599,10 @@ async function main() {
       'oauth_email_merge_verified=verified',
       'oauth_email_merge_claimed=claimed',
       'oauth_email_merge_source_auth_sessions=0',
+      'oauth_email_merge_identity_insert_blocked=0',
+      'oauth_email_merge_atomic_rollback=true',
+      'oauth_email_merge_quarantined=claimed',
+      'oauth_email_merge_quarantine_state=true',
       'oauth_email_merge_transferred=ownership_transferred',
       'oauth_email_merge_completed=completed',
       'oauth_email_merge_owner=00000000-0000-4000-8000-000000000010',
@@ -1505,6 +1618,8 @@ async function main() {
       'oauth_email_consumed_merge_started=pending',
       'oauth_email_consumed_merge_verified=verified',
       'oauth_email_consumed_merge_claimed=claimed',
+      'oauth_email_consumed_quarantined=claimed',
+      'oauth_email_consumed_quarantine_state=true',
       'oauth_email_consumed_auth_sessions=0',
       'oauth_email_consumed_refresh_tokens=0',
       'admin_security_definer_browser_grants=0',

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -30,7 +30,7 @@
 
 2026-08-01 的真实本地 Supabase/PostgreSQL 17 空库导入已补齐两项此前静态检查未覆盖的边界：`archive/004_tickets_system.sql` 必须在表不存在时也能执行清理；Phase A/B 必须显式授予 `service_role` 访问 `profiles` 与私有 Session 撤销状态所需的 DML 权限，同时保持 `anon/authenticated` 对私有撤销状态的拒绝。`test:supabase-baseline:smoke` 与 `test:auth-hardening-phase-a` 已加入对应回归断言。
 
-本分支 baseline 覆盖到 `active/171_allow_consumed_magiclink_email_artifact.sql` 后，不要再把 `001~171` 的主站标准迁移重复叠加到同版本 baseline。主站发布链原到 158；共享生产 schema 另含独立抽奖 160–165。认证 166/167/168 已按顺序生产应用并通过回填、权限、函数、RLS 与触发器核验；迁移 169 已生产应用（PR #15），主线另含正式导入修复迁移 170（PR #16）；迁移 171 是本分支新增候选，尚未生产应用。
+本分支 baseline 覆盖到 `active/172_quarantine_oauth_email_artifact_atomically.sql` 后，不要再把 `001~172` 的主站标准迁移重复叠加到同版本 baseline。主站发布链原到 158；共享生产 schema 另含独立抽奖 160–165。认证 166/167/168 已按顺序生产应用并通过回填、权限、函数、RLS 与触发器核验；迁移 169 已生产应用（PR #15），正式导入修复迁移 170 已生产应用（PR #16），consumed Magic Link 空壳识别迁移 171 已生产应用（PR #17）。迁移 172 将 claim 后的 Auth 空壳邮箱、唯一 email identity、封禁和 intent metadata 改为数据库内一次性隔离，并在活动 intent 期间冻结 identity 的新增、删除和非预期修改，避免 GoTrue Admin 多步更新暴露的中间状态。
 
 ### migration 编号说明
 
@@ -39,6 +39,7 @@
 - **本分支 168：** `migrations/168_close_auth_review_findings.sql`（历史 identity 哈希兼容、直连 RLS Session 门禁和首次设密并发收口；必须先于依赖新 RPC 的 API 部署）。
 - **本分支 169：** `migrations/169_add_oauth_email_artifact_merge.sql`（只针对旧版验证流程产生且经严格证据确认无任何站内数据的 Auth 空壳，提供一次性邮箱验证、显式确认、归属转移、会话撤销和补偿账本；不是通用账号合并）。
 - **本分支 171：** `migrations/171_allow_consumed_magiclink_email_artifact.sql`（识别旧缺陷第二种形状：点击过旧 Magic Link 并留下占位 bcrypt 密码与原生 Session/refresh token 的空壳；要求独立证据版本 `legacy_magiclink_consumed_v2`、真实工单与 super_admin 批准人、完整证据快照哈希绑定；`service_role` 对批准表只读，claim 先锁定批准行再复核）。
+- **本分支 172：** `migrations/172_quarantine_oauth_email_artifact_atomically.sql`（通过 service-role-only 的 `SECURITY DEFINER` RPC 在一个数据库事务中同时隔离 Auth 空壳用户和唯一 email identity，并用 identity 冻结触发器阻断活动 intent 期间的并发新增、删除和非预期更新；应用层对结果不明执行幂等重试，仍无法确认时进入人工协调状态）。
 - **其他 worktree 仍占用同号文件名（不得与本文件一起部署）：**
   - 主脏树性能线：`159_add_history_scope_read_models.sql`
   - 邮箱候选树：`159_bind_email_verification_to_target.sql`

--- a/supabase/baseline/000_complete_schema.sql
+++ b/supabase/baseline/000_complete_schema.sql
@@ -5,8 +5,8 @@
 --   1. 此文件由 scripts/generate-supabase-baseline.mjs 自动生成
 --   2. 合并 supabase/archive/migrations/ 与 supabase/migrations/ 中的标准前向迁移
 --   3. 不包含 supabase/manual/ 下的 destructive / rollback / data-backfill 脚本
---   4. 生成时间: 2026-08-03T17:22:48.013Z
---   5. 覆盖范围: archive/001_init_tables.sql -> active/171_allow_consumed_magiclink_email_artifact.sql
+--   4. 生成时间: 2026-08-04T15:04:09.399Z
+--   5. 覆盖范围: archive/001_init_tables.sql -> active/172_quarantine_oauth_email_artifact_atomically.sql
 -- ============================================
 
 -- >>> BEGIN MIGRATION: archive/001_init_tables.sql
@@ -29626,4 +29626,293 @@ COMMENT ON FUNCTION public.inspect_oauth_email_artifact_merge(UUID, TEXT, BOOLEA
 
 NOTIFY pgrst, 'reload schema';
 -- <<< END MIGRATION: active/171_allow_consumed_magiclink_email_artifact.sql
+
+-- >>> BEGIN MIGRATION: active/172_quarantine_oauth_email_artifact_atomically.sql
+-- 172: quarantine an approved OAuth email artifact inside one database
+-- transaction instead of sending a multi-step update through GoTrue Admin.
+--
+-- GoTrue v2.188.1 confirms the user, updates the email identity, changes the
+-- Auth email, writes metadata, and applies the ban as separate SQL updates.
+-- The merge freeze trigger correctly rejects those intermediate states. This
+-- RPC preserves that freeze and only writes the exact final quarantine state.
+
+CREATE OR REPLACE FUNCTION public.quarantine_oauth_email_artifact_for_merge(
+  p_intent_id UUID,
+  p_source_user_id UUID
+)
+RETURNS SETOF public.account_email_merge_intents
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = extensions, public, auth, pg_temp
+SET row_security = off
+AS $$
+DECLARE
+  v_intent public.account_email_merge_intents%ROWTYPE;
+  v_approval public.account_email_artifact_merge_approvals%ROWTYPE;
+  v_source auth.users%ROWTYPE;
+  v_artifact auth.users%ROWTYPE;
+  v_identity RECORD;
+  v_identity_count INTEGER;
+  v_updated_count INTEGER;
+  v_artifact_metadata JSONB;
+BEGIN
+  SELECT * INTO v_intent
+  FROM public.account_email_merge_intents
+  WHERE id = p_intent_id
+    AND source_user_id = p_source_user_id;
+
+  IF v_intent.id IS NULL THEN
+    RETURN;
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('account-email-user:' || v_intent.source_user_id::TEXT, 0)
+  );
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('account-email-value:' || v_intent.target_email, 0)
+  );
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('account-email-user:' || v_intent.artifact_user_id::TEXT, 0)
+  );
+
+  SELECT * INTO v_intent
+  FROM public.account_email_merge_intents
+  WHERE id = p_intent_id
+    AND source_user_id = p_source_user_id
+  FOR UPDATE;
+
+  IF v_intent.status NOT IN ('claimed', 'ownership_transferred') THEN
+    RETURN;
+  END IF;
+
+  SELECT * INTO v_approval
+  FROM public.account_email_artifact_merge_approvals AS approval
+  WHERE approval.artifact_user_id = v_intent.artifact_user_id
+  FOR UPDATE;
+
+  IF v_approval.artifact_user_id IS NULL
+    OR v_approval.source_user_id IS DISTINCT FROM v_intent.source_user_id
+    OR v_approval.target_email_hash IS DISTINCT FROM ENCODE(
+      extensions.DIGEST(v_intent.target_email, 'sha256'),
+      'hex'
+    )
+    OR v_approval.approval_reference_hash IS DISTINCT FROM ENCODE(
+      extensions.DIGEST('ticket:' || v_approval.approval_ticket_id::TEXT, 'sha256'),
+      'hex'
+    )
+    OR v_approval.evidence_version NOT IN (
+      'legacy_magiclink_v1',
+      'legacy_magiclink_consumed_v2'
+    )
+    OR v_approval.revoked_at IS NOT NULL
+    OR v_approval.expires_at <= NOW()
+    OR NOT EXISTS (
+      SELECT 1
+      FROM public.tickets AS ticket
+      WHERE ticket.id = v_approval.approval_ticket_id
+        AND ticket.user_id = v_intent.source_user_id
+    )
+    OR NOT EXISTS (
+      SELECT 1
+      FROM public.profiles AS operator_profile
+      WHERE operator_profile.id = v_approval.approved_by
+        AND operator_profile.role = 'super_admin'
+    ) THEN
+    RAISE EXCEPTION 'oauth_email_artifact_quarantine_approval_invalid'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT * INTO v_source
+  FROM auth.users
+  WHERE id = v_intent.source_user_id
+  FOR UPDATE;
+
+  SELECT * INTO v_artifact
+  FROM auth.users
+  WHERE id = v_intent.artifact_user_id
+  FOR UPDATE;
+
+  IF v_source.id IS NULL
+    OR v_artifact.id IS NULL
+    OR (
+      public.normalize_account_email(v_source.email) NOT LIKE '%@oauth.local.invalid'
+      AND LOWER(COALESCE(v_source.raw_user_meta_data ->> 'synthetic_oauth_email', 'false')) <> 'true'
+    ) THEN
+    RAISE EXCEPTION 'oauth_email_artifact_quarantine_source_changed'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT COUNT(*) INTO v_identity_count
+  FROM auth.identities AS identity
+  WHERE identity.user_id = v_intent.artifact_user_id;
+
+  SELECT * INTO v_identity
+  FROM auth.identities AS identity
+  WHERE identity.user_id = v_intent.artifact_user_id
+  ORDER BY identity.id
+  LIMIT 1
+  FOR UPDATE;
+
+  IF public.normalize_account_email(v_artifact.email) = v_intent.quarantine_email
+    AND v_artifact.raw_user_meta_data ->> 'oauth_email_merge_intent_id' = v_intent.id::TEXT
+    AND v_artifact.banned_until > NOW()
+    AND v_identity_count = 1
+    AND v_identity.provider = 'email'
+    AND public.normalize_account_email(v_identity.identity_data ->> 'email') = v_intent.quarantine_email
+    AND LOWER(COALESCE(v_identity.identity_data ->> 'email_verified', 'false')) = 'true' THEN
+    RETURN NEXT v_intent;
+    RETURN;
+  END IF;
+
+  IF public.normalize_account_email(v_artifact.email) <> v_intent.target_email
+    OR v_artifact.raw_user_meta_data ? 'oauth_email_merge_intent_id'
+    OR v_identity_count <> 1
+    OR v_identity.provider <> 'email'
+    OR public.normalize_account_email(v_identity.identity_data ->> 'email') <> v_intent.target_email
+    OR EXISTS (
+      SELECT 1
+      FROM auth.users AS other_user
+      WHERE other_user.id <> v_intent.artifact_user_id
+        AND public.normalize_account_email(other_user.email) = v_intent.quarantine_email
+    )
+    OR NOT EXISTS (
+      SELECT 1
+      FROM public.account_email_ownerships AS ownership
+      WHERE ownership.normalized_email = v_intent.target_email
+        AND ownership.user_id = v_intent.artifact_user_id
+    ) THEN
+    RAISE EXCEPTION 'oauth_email_artifact_quarantine_state_changed'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE auth.identities
+  SET
+    identity_data = identity_data || JSONB_BUILD_OBJECT(
+      'email', v_intent.quarantine_email,
+      'email_verified', TRUE
+    ),
+    updated_at = NOW()
+  WHERE id = v_identity.id
+    AND user_id = v_intent.artifact_user_id
+    AND provider = 'email';
+
+  GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+  IF v_updated_count <> 1 THEN
+    RAISE EXCEPTION 'oauth_email_artifact_quarantine_identity_changed'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  v_artifact_metadata := COALESCE(v_artifact.raw_user_meta_data, '{}'::JSONB)
+    || JSONB_BUILD_OBJECT(
+      'legacy_email_action_artifact', TRUE,
+      'legacy_email_released_at', NOW(),
+      'oauth_email_merge_intent_id', v_intent.id::TEXT
+    );
+
+  UPDATE auth.users
+  SET
+    email = v_intent.quarantine_email,
+    raw_user_meta_data = v_artifact_metadata,
+    banned_until = NOW() + INTERVAL '100 years',
+    updated_at = NOW()
+  WHERE id = v_intent.artifact_user_id
+    AND public.normalize_account_email(email) = v_intent.target_email
+    AND NOT (COALESCE(raw_user_meta_data, '{}'::JSONB) ? 'oauth_email_merge_intent_id');
+
+  GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+  IF v_updated_count <> 1 THEN
+    RAISE EXCEPTION 'oauth_email_artifact_quarantine_user_changed'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  RETURN NEXT v_intent;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.protect_oauth_email_artifact_merge_identity()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth, pg_temp
+AS $$
+DECLARE
+  v_user_id UUID;
+  v_intent public.account_email_merge_intents%ROWTYPE;
+BEGIN
+  v_user_id := CASE
+    WHEN TG_OP = 'DELETE' THEN OLD.user_id
+    ELSE NEW.user_id
+  END;
+
+  SELECT * INTO v_intent
+  FROM public.account_email_merge_intents
+  WHERE artifact_user_id = v_user_id
+    AND status IN ('claimed', 'ownership_transferred')
+  ORDER BY created_at DESC
+  LIMIT 1;
+
+  IF v_intent.id IS NULL THEN
+    IF TG_OP = 'DELETE' THEN
+      RETURN OLD;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE'
+    AND NEW.id IS NOT DISTINCT FROM OLD.id
+    AND NEW.user_id IS NOT DISTINCT FROM OLD.user_id
+    AND NEW.provider = 'email'
+    AND OLD.provider = 'email'
+    AND public.normalize_account_email(OLD.identity_data ->> 'email') = v_intent.target_email
+    AND public.normalize_account_email(NEW.identity_data ->> 'email') = v_intent.quarantine_email
+    AND LOWER(COALESCE(NEW.identity_data ->> 'email_verified', 'false')) = 'true'
+    AND (
+      COALESCE(NEW.identity_data, '{}'::JSONB) - ARRAY['email', 'email_verified']::TEXT[]
+    ) IS NOT DISTINCT FROM (
+      COALESCE(OLD.identity_data, '{}'::JSONB) - ARRAY['email', 'email_verified']::TEXT[]
+    )
+    AND (
+      TO_JSONB(NEW) - ARRAY['identity_data', 'updated_at', 'email']::TEXT[]
+    ) IS NOT DISTINCT FROM (
+      TO_JSONB(OLD) - ARRAY['identity_data', 'updated_at', 'email']::TEXT[]
+    ) THEN
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION 'oauth_email_merge_artifact_identity_frozen'
+    USING ERRCODE = '55000';
+END;
+$$;
+
+DO $$
+BEGIN
+  IF TO_REGCLASS('auth.identities') IS NOT NULL THEN
+    DROP TRIGGER IF EXISTS protect_oauth_email_artifact_merge_identity
+      ON auth.identities;
+    CREATE TRIGGER protect_oauth_email_artifact_merge_identity
+      BEFORE INSERT OR UPDATE OR DELETE ON auth.identities
+      FOR EACH ROW EXECUTE FUNCTION public.protect_oauth_email_artifact_merge_identity();
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.quarantine_oauth_email_artifact_for_merge(UUID, UUID)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.protect_oauth_email_artifact_merge_identity()
+  FROM PUBLIC, anon, authenticated, service_role;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+    GRANT EXECUTE ON FUNCTION public.quarantine_oauth_email_artifact_for_merge(UUID, UUID)
+      TO service_role;
+  END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION public.quarantine_oauth_email_artifact_for_merge(UUID, UUID) IS
+  'Atomically moves a claimed empty Auth artifact and its sole email identity to the intent quarantine address without exposing trigger-unsafe GoTrue intermediate states.';
+
+NOTIFY pgrst, 'reload schema';
+-- <<< END MIGRATION: active/172_quarantine_oauth_email_artifact_atomically.sql
 

--- a/supabase/migrations/172_quarantine_oauth_email_artifact_atomically.sql
+++ b/supabase/migrations/172_quarantine_oauth_email_artifact_atomically.sql
@@ -1,0 +1,286 @@
+-- 172: quarantine an approved OAuth email artifact inside one database
+-- transaction instead of sending a multi-step update through GoTrue Admin.
+--
+-- GoTrue v2.188.1 confirms the user, updates the email identity, changes the
+-- Auth email, writes metadata, and applies the ban as separate SQL updates.
+-- The merge freeze trigger correctly rejects those intermediate states. This
+-- RPC preserves that freeze and only writes the exact final quarantine state.
+
+CREATE OR REPLACE FUNCTION public.quarantine_oauth_email_artifact_for_merge(
+  p_intent_id UUID,
+  p_source_user_id UUID
+)
+RETURNS SETOF public.account_email_merge_intents
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = extensions, public, auth, pg_temp
+SET row_security = off
+AS $$
+DECLARE
+  v_intent public.account_email_merge_intents%ROWTYPE;
+  v_approval public.account_email_artifact_merge_approvals%ROWTYPE;
+  v_source auth.users%ROWTYPE;
+  v_artifact auth.users%ROWTYPE;
+  v_identity RECORD;
+  v_identity_count INTEGER;
+  v_updated_count INTEGER;
+  v_artifact_metadata JSONB;
+BEGIN
+  SELECT * INTO v_intent
+  FROM public.account_email_merge_intents
+  WHERE id = p_intent_id
+    AND source_user_id = p_source_user_id;
+
+  IF v_intent.id IS NULL THEN
+    RETURN;
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('account-email-user:' || v_intent.source_user_id::TEXT, 0)
+  );
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('account-email-value:' || v_intent.target_email, 0)
+  );
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('account-email-user:' || v_intent.artifact_user_id::TEXT, 0)
+  );
+
+  SELECT * INTO v_intent
+  FROM public.account_email_merge_intents
+  WHERE id = p_intent_id
+    AND source_user_id = p_source_user_id
+  FOR UPDATE;
+
+  IF v_intent.status NOT IN ('claimed', 'ownership_transferred') THEN
+    RETURN;
+  END IF;
+
+  SELECT * INTO v_approval
+  FROM public.account_email_artifact_merge_approvals AS approval
+  WHERE approval.artifact_user_id = v_intent.artifact_user_id
+  FOR UPDATE;
+
+  IF v_approval.artifact_user_id IS NULL
+    OR v_approval.source_user_id IS DISTINCT FROM v_intent.source_user_id
+    OR v_approval.target_email_hash IS DISTINCT FROM ENCODE(
+      extensions.DIGEST(v_intent.target_email, 'sha256'),
+      'hex'
+    )
+    OR v_approval.approval_reference_hash IS DISTINCT FROM ENCODE(
+      extensions.DIGEST('ticket:' || v_approval.approval_ticket_id::TEXT, 'sha256'),
+      'hex'
+    )
+    OR v_approval.evidence_version NOT IN (
+      'legacy_magiclink_v1',
+      'legacy_magiclink_consumed_v2'
+    )
+    OR v_approval.revoked_at IS NOT NULL
+    OR v_approval.expires_at <= NOW()
+    OR NOT EXISTS (
+      SELECT 1
+      FROM public.tickets AS ticket
+      WHERE ticket.id = v_approval.approval_ticket_id
+        AND ticket.user_id = v_intent.source_user_id
+    )
+    OR NOT EXISTS (
+      SELECT 1
+      FROM public.profiles AS operator_profile
+      WHERE operator_profile.id = v_approval.approved_by
+        AND operator_profile.role = 'super_admin'
+    ) THEN
+    RAISE EXCEPTION 'oauth_email_artifact_quarantine_approval_invalid'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT * INTO v_source
+  FROM auth.users
+  WHERE id = v_intent.source_user_id
+  FOR UPDATE;
+
+  SELECT * INTO v_artifact
+  FROM auth.users
+  WHERE id = v_intent.artifact_user_id
+  FOR UPDATE;
+
+  IF v_source.id IS NULL
+    OR v_artifact.id IS NULL
+    OR (
+      public.normalize_account_email(v_source.email) NOT LIKE '%@oauth.local.invalid'
+      AND LOWER(COALESCE(v_source.raw_user_meta_data ->> 'synthetic_oauth_email', 'false')) <> 'true'
+    ) THEN
+    RAISE EXCEPTION 'oauth_email_artifact_quarantine_source_changed'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT COUNT(*) INTO v_identity_count
+  FROM auth.identities AS identity
+  WHERE identity.user_id = v_intent.artifact_user_id;
+
+  SELECT * INTO v_identity
+  FROM auth.identities AS identity
+  WHERE identity.user_id = v_intent.artifact_user_id
+  ORDER BY identity.id
+  LIMIT 1
+  FOR UPDATE;
+
+  IF public.normalize_account_email(v_artifact.email) = v_intent.quarantine_email
+    AND v_artifact.raw_user_meta_data ->> 'oauth_email_merge_intent_id' = v_intent.id::TEXT
+    AND v_artifact.banned_until > NOW()
+    AND v_identity_count = 1
+    AND v_identity.provider = 'email'
+    AND public.normalize_account_email(v_identity.identity_data ->> 'email') = v_intent.quarantine_email
+    AND LOWER(COALESCE(v_identity.identity_data ->> 'email_verified', 'false')) = 'true' THEN
+    RETURN NEXT v_intent;
+    RETURN;
+  END IF;
+
+  IF public.normalize_account_email(v_artifact.email) <> v_intent.target_email
+    OR v_artifact.raw_user_meta_data ? 'oauth_email_merge_intent_id'
+    OR v_identity_count <> 1
+    OR v_identity.provider <> 'email'
+    OR public.normalize_account_email(v_identity.identity_data ->> 'email') <> v_intent.target_email
+    OR EXISTS (
+      SELECT 1
+      FROM auth.users AS other_user
+      WHERE other_user.id <> v_intent.artifact_user_id
+        AND public.normalize_account_email(other_user.email) = v_intent.quarantine_email
+    )
+    OR NOT EXISTS (
+      SELECT 1
+      FROM public.account_email_ownerships AS ownership
+      WHERE ownership.normalized_email = v_intent.target_email
+        AND ownership.user_id = v_intent.artifact_user_id
+    ) THEN
+    RAISE EXCEPTION 'oauth_email_artifact_quarantine_state_changed'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE auth.identities
+  SET
+    identity_data = identity_data || JSONB_BUILD_OBJECT(
+      'email', v_intent.quarantine_email,
+      'email_verified', TRUE
+    ),
+    updated_at = NOW()
+  WHERE id = v_identity.id
+    AND user_id = v_intent.artifact_user_id
+    AND provider = 'email';
+
+  GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+  IF v_updated_count <> 1 THEN
+    RAISE EXCEPTION 'oauth_email_artifact_quarantine_identity_changed'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  v_artifact_metadata := COALESCE(v_artifact.raw_user_meta_data, '{}'::JSONB)
+    || JSONB_BUILD_OBJECT(
+      'legacy_email_action_artifact', TRUE,
+      'legacy_email_released_at', NOW(),
+      'oauth_email_merge_intent_id', v_intent.id::TEXT
+    );
+
+  UPDATE auth.users
+  SET
+    email = v_intent.quarantine_email,
+    raw_user_meta_data = v_artifact_metadata,
+    banned_until = NOW() + INTERVAL '100 years',
+    updated_at = NOW()
+  WHERE id = v_intent.artifact_user_id
+    AND public.normalize_account_email(email) = v_intent.target_email
+    AND NOT (COALESCE(raw_user_meta_data, '{}'::JSONB) ? 'oauth_email_merge_intent_id');
+
+  GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+  IF v_updated_count <> 1 THEN
+    RAISE EXCEPTION 'oauth_email_artifact_quarantine_user_changed'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  RETURN NEXT v_intent;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.protect_oauth_email_artifact_merge_identity()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth, pg_temp
+AS $$
+DECLARE
+  v_user_id UUID;
+  v_intent public.account_email_merge_intents%ROWTYPE;
+BEGIN
+  v_user_id := CASE
+    WHEN TG_OP = 'DELETE' THEN OLD.user_id
+    ELSE NEW.user_id
+  END;
+
+  SELECT * INTO v_intent
+  FROM public.account_email_merge_intents
+  WHERE artifact_user_id = v_user_id
+    AND status IN ('claimed', 'ownership_transferred')
+  ORDER BY created_at DESC
+  LIMIT 1;
+
+  IF v_intent.id IS NULL THEN
+    IF TG_OP = 'DELETE' THEN
+      RETURN OLD;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE'
+    AND NEW.id IS NOT DISTINCT FROM OLD.id
+    AND NEW.user_id IS NOT DISTINCT FROM OLD.user_id
+    AND NEW.provider = 'email'
+    AND OLD.provider = 'email'
+    AND public.normalize_account_email(OLD.identity_data ->> 'email') = v_intent.target_email
+    AND public.normalize_account_email(NEW.identity_data ->> 'email') = v_intent.quarantine_email
+    AND LOWER(COALESCE(NEW.identity_data ->> 'email_verified', 'false')) = 'true'
+    AND (
+      COALESCE(NEW.identity_data, '{}'::JSONB) - ARRAY['email', 'email_verified']::TEXT[]
+    ) IS NOT DISTINCT FROM (
+      COALESCE(OLD.identity_data, '{}'::JSONB) - ARRAY['email', 'email_verified']::TEXT[]
+    )
+    AND (
+      TO_JSONB(NEW) - ARRAY['identity_data', 'updated_at', 'email']::TEXT[]
+    ) IS NOT DISTINCT FROM (
+      TO_JSONB(OLD) - ARRAY['identity_data', 'updated_at', 'email']::TEXT[]
+    ) THEN
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION 'oauth_email_merge_artifact_identity_frozen'
+    USING ERRCODE = '55000';
+END;
+$$;
+
+DO $$
+BEGIN
+  IF TO_REGCLASS('auth.identities') IS NOT NULL THEN
+    DROP TRIGGER IF EXISTS protect_oauth_email_artifact_merge_identity
+      ON auth.identities;
+    CREATE TRIGGER protect_oauth_email_artifact_merge_identity
+      BEFORE INSERT OR UPDATE OR DELETE ON auth.identities
+      FOR EACH ROW EXECUTE FUNCTION public.protect_oauth_email_artifact_merge_identity();
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.quarantine_oauth_email_artifact_for_merge(UUID, UUID)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.protect_oauth_email_artifact_merge_identity()
+  FROM PUBLIC, anon, authenticated, service_role;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+    GRANT EXECUTE ON FUNCTION public.quarantine_oauth_email_artifact_for_merge(UUID, UUID)
+      TO service_role;
+  END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION public.quarantine_oauth_email_artifact_for_merge(UUID, UUID) IS
+  'Atomically moves a claimed empty Auth artifact and its sole email identity to the intent quarantine address without exposing trigger-unsafe GoTrue intermediate states.';
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- 将 OAuth 邮箱空壳及唯一 email identity 改为数据库事务内原子隔离，避免 GoTrue Admin 多步更新触发冻结失败
- 活动 intent 期间冻结空壳 identity 的并发新增、删除和非预期更新；隔离响应不明时幂等重试并安全转人工协调
- 增加原子回滚、identity 并发、v1/v2 隔离不变量和响应丢失回归，baseline 前进到迁移 172

## Test plan
- [x] `npm run test:auth-hardening-phase-cd`
- [x] `npm run test:supabase-baseline`
- [x] `npm run test:supabase-baseline:smoke`
- [x] `npm run test:unit`（184 files / 1011 tests）
- [x] `npm run lint`
- [x] `npm run build`

## Production incident
- 真实请求已确认失败于 GoTrue `PUT /admin/users/...`，数据库错误为 `oauth_email_merge_artifact_frozen`
- 原流程补偿成功，邮箱归属未转移；双方原生 Auth Session / refresh token 已按 claim 设计撤销
- 发布顺序：先备份并应用迁移 172，再部署应用代码，最后对既有已验证 intent 执行受控恢复核验