### PR TITLE
ci: 迁移个人分析Worker到GitHub Actions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,16 @@ MAIL_OUTBOX_GLOBAL_KILL_SWITCH=true
 # 内部队列处理 endpoint secret。/api/mail-outbox-worker 同时接受此值和 CRON_SECRET，
 # 方便 Vercel Cron 使用 Authorization: Bearer <CRON_SECRET> 触发；生产仍建议单独设置此值给外部 cron / 运维脚本。
 MAIL_OUTBOX_WORKER_SECRET=
+
+# 私有个人分析快照 Worker。生产调度由 GitHub Actions
+# `.github/workflows/personal-analysis-worker.yml` 每 5 分钟调用一次，
+# 不再使用 Vercel 高频 Cron（Hobby 套餐只允许每日 Cron）。
+PERSONAL_ANALYSIS_WORKER_ENABLED=false
+PERSONAL_ANALYSIS_WORKER_SECRET=
+# 单次调用默认只领取一个队列作业，避免超过 Vercel 函数时限。
+PERSONAL_ANALYSIS_WORKER_BATCH_SIZE=1
+# 仅用于本地无持久快照时的同步回退；生产环境应保持关闭。
+PERSONAL_ANALYSIS_TRANSIENT_FALLBACK=false
 STALWART_SMTP_HOST=
 STALWART_SMTP_PORT=587
 STALWART_SMTP_USERNAME=

--- a/.github/workflows/personal-analysis-worker.yml
+++ b/.github/workflows/personal-analysis-worker.yml
@@ -1,0 +1,99 @@
+name: Personal Analysis Worker
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: personal-analysis-worker-production
+  cancel-in-progress: false
+
+jobs:
+  run-worker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      WORKER_URL: ${{ vars.PERSONAL_ANALYSIS_WORKER_URL || 'https://ef-gacha.mogujun.icu/api/personal-analysis-worker' }}
+      WORKER_SECRET: ${{ secrets.PERSONAL_ANALYSIS_WORKER_SECRET }}
+
+    steps:
+      - name: Validate worker configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${WORKER_SECRET}" ]]; then
+            echo "::error::Repository secret PERSONAL_ANALYSIS_WORKER_SECRET is not configured."
+            exit 1
+          fi
+          if [[ ! "${WORKER_URL}" =~ ^https:// ]]; then
+            echo "::error::PERSONAL_ANALYSIS_WORKER_URL must use HTTPS."
+            exit 1
+          fi
+
+      - name: Run personal analysis worker
+        shell: bash
+        run: |
+          set -euo pipefail
+          response_file="$(mktemp)"
+          trap 'rm -f "${response_file}"' EXIT
+
+          for attempt in 1 2 3; do
+            http_code="$(
+              curl \
+                --silent \
+                --show-error \
+                --request POST \
+                --connect-timeout 15 \
+                --max-time 75 \
+                --output "${response_file}" \
+                --write-out '%{http_code}' \
+                --header "Authorization: Bearer ${WORKER_SECRET}" \
+                --header 'Content-Type: application/json' \
+                "${WORKER_URL}" \
+                || true
+            )"
+
+            if [[ "${http_code}" =~ ^2[0-9][0-9]$ ]]; then
+              if node --input-type=module - "${response_file}" <<'NODE'
+          import { readFile } from 'node:fs/promises';
+
+          const responsePath = process.argv[2];
+          const payload = JSON.parse(await readFile(responsePath, 'utf8'));
+          const result = payload?.result || {};
+          if (
+            payload?.success !== true
+            || payload?.partial === true
+            || result?.ok === false
+            || result?.skipped === true
+          ) {
+            process.exit(1);
+          }
+
+          const stats = result?.stats || {};
+          console.log(JSON.stringify({
+            code: result?.code || null,
+            claimedOwner: Number(stats.claimedOwner || 0),
+            claimedScope: Number(stats.claimedScope || 0),
+            succeeded: Number(stats.succeeded || 0),
+            stale: Number(stats.stale || 0),
+            failed: Number(stats.failed || 0),
+            backfillHasMore: Boolean(result?.backfill?.hasMore),
+          }));
+          NODE
+              then
+                exit 0
+              fi
+            fi
+
+            echo "::warning::Worker attempt ${attempt}/3 failed with HTTP ${http_code:-transport-error}."
+            if [[ "${attempt}" -lt 3 ]]; then
+              sleep "$((attempt * 10))"
+            fi
+          done
+
+          echo "::error::Personal analysis worker failed after 3 attempts."
+          exit 1

--- a/api/__tests__/personalAnalysisWorkerSchedule.test.js
+++ b/api/__tests__/personalAnalysisWorkerSchedule.test.js
@@ -1,0 +1,40 @@
+// @vitest-environment node
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const projectRoot = process.cwd();
+
+describe('personal analysis worker production schedule', () => {
+  it('keeps the high-frequency worker out of Vercel Hobby cron', async () => {
+    const config = JSON.parse(await readFile(
+      path.join(projectRoot, 'vercel.json'),
+      'utf8'
+    ));
+
+    expect(config.crons).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: '/api/ops-automation' }),
+      expect.objectContaining({ path: '/api/mail-outbox-worker' }),
+    ]));
+    expect(config.crons).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: '/api/personal-analysis-worker' }),
+    ]));
+  });
+
+  it('schedules an authenticated and validated GitHub Actions worker call', async () => {
+    const workflow = await readFile(
+      path.join(projectRoot, '.github', 'workflows', 'personal-analysis-worker.yml'),
+      'utf8'
+    );
+
+    expect(workflow).toContain("cron: '*/5 * * * *'");
+    expect(workflow).toContain('workflow_dispatch:');
+    expect(workflow).toContain('secrets.PERSONAL_ANALYSIS_WORKER_SECRET');
+    expect(workflow).toContain('/api/personal-analysis-worker');
+    expect(workflow).toContain('Authorization: Bearer ${WORKER_SECRET}');
+    expect(workflow).toContain('result?.skipped === true');
+    expect(workflow).toContain('payload?.partial === true');
+    expect(workflow).toContain('for attempt in 1 2 3');
+  });
+});

--- a/docs/PERSONAL_ANALYSIS_WORKER.md
+++ b/docs/PERSONAL_ANALYSIS_WORKER.md
@@ -1,0 +1,56 @@
+# 个人分析快照 Worker 调度
+
+个人分析快照由 `/api/personal-analysis-worker` 异步生成。生产环境使用
+GitHub Actions Scheduled Workflow 调度，不使用 Vercel 高频 Cron，避免 Hobby
+套餐因 `* * * * *` 每分钟任务拒绝整个部署。
+
+## 调度方式
+
+- Workflow：`.github/workflows/personal-analysis-worker.yml`
+- 默认频率：每 5 分钟
+- 默认地址：`https://ef-gacha.mogujun.icu/api/personal-analysis-worker`
+- 支持在 Actions 页面通过 `workflow_dispatch` 手动执行
+- 同一时间最多执行一个任务，后续触发会等待前一次完成
+- 单次调用失败会重试 3 次，并校验 HTTP 与 Worker JSON 状态
+
+GitHub 的 Scheduled Workflow 只从默认分支读取。Workflow 合并到 `main` 后才会
+开始定时执行；GitHub 在高负载时可能延迟计划任务。
+
+## 必需配置
+
+### Vercel Production
+
+```text
+PERSONAL_ANALYSIS_WORKER_ENABLED=true
+PERSONAL_ANALYSIS_WORKER_SECRET=<随机高强度密钥>
+```
+
+`SUPABASE_SECRET_KEY`（或兼容的 service role key）也必须可用。单次任务默认只
+领取一个队列作业，以避免超过 Vercel 函数执行时限。
+
+### GitHub Repository Actions Secret
+
+在仓库 `Settings → Secrets and variables → Actions` 中添加：
+
+```text
+PERSONAL_ANALYSIS_WORKER_SECRET=<与 Vercel 完全相同的值>
+```
+
+可选 Repository Variable：
+
+```text
+PERSONAL_ANALYSIS_WORKER_URL=https://你的生产域名/api/personal-analysis-worker
+```
+
+未设置 URL Variable 时使用主站默认地址。
+
+## 验证
+
+1. 部署包含 Worker 环境变量的新 Production。
+2. 在 GitHub Actions 中手动运行 `Personal Analysis Worker`。
+3. Workflow 输出应包含受控统计，例如 `claimedOwner`、`claimedScope`、
+   `succeeded`、`failed`，但不会输出用户 ID 或 Secret。
+4. 检查 `personal_analysis_snapshots` 开始生成，队列 lease 与 attempt 发生变化。
+
+如果 Worker 未启用、Secret 不匹配、返回 partial 或 skipped，Workflow 会失败，
+不会把降级响应误判为成功。

--- a/vercel.json
+++ b/vercel.json
@@ -90,10 +90,6 @@
       "schedule": "20 2 * * *"
     },
     {
-      "path": "/api/personal-analysis-worker",
-      "schedule": "* * * * *"
-    },
-    {
       "path": "/api/summer-lottery-contact-retention",
       "schedule": "35 3 * * *"
     }


### PR DESCRIPTION
## Summary

- 将个人分析快照 Worker 从 Vercel 每分钟 Cron 迁移到 GitHub Actions 每 5 分钟调度，恢复 Hobby 套餐部署
- 使用专用 Secret、HTTPS 校验、并发串行、三次重试和 Worker JSON 状态校验，避免降级响应误判成功
- 补充环境变量、运维文档和静态回归测试，防止高频 Cron 被重新加入 Vercel

## Test plan

- [x] Workflow YAML 通过 Prettier 解析
- [x] Worker 调度、路由鉴权与执行测试（14 tests）
- [x] `npm run lint`
- [x] `npm run build`
- [x] GitHub Secret / Variable 和 Vercel Production 环境变量已配置