### PR TITLE
fix: 跳过个人分析Worker重复全量回填

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -121,6 +121,8 @@ MAIL_OUTBOX_WORKER_SECRET=
 # 不再使用 Vercel 高频 Cron（Hobby 套餐只允许每日 Cron）。
 PERSONAL_ANALYSIS_WORKER_ENABLED=false
 PERSONAL_ANALYSIS_WORKER_SECRET=
+# 常规五分钟任务保持 false；仅人工执行一次性历史回填时临时开启。
+PERSONAL_ANALYSIS_WORKER_BACKFILL_ENABLED=false
 # 单次调用默认只领取一个队列作业，避免超过 Vercel 函数时限。
 PERSONAL_ANALYSIS_WORKER_BATCH_SIZE=1
 # 仅用于本地无持久快照时的同步回退；生产环境应保持关闭。

--- a/api/__tests__/personalAnalysisWorker.test.js
+++ b/api/__tests__/personalAnalysisWorker.test.js
@@ -148,6 +148,7 @@ function createAdminClient({
 function enabledConfig(overrides = {}) {
   return {
     enabled: true,
+    backfillEnabled: true,
     batchSize: 1,
     backfillBatchSize: 100,
     leaseSeconds: 50,
@@ -211,6 +212,34 @@ describe('personal analysis worker', () => {
       hasMore: true,
     });
     expect(JSON.stringify(result)).not.toContain(USER_ID);
+  });
+
+  it('skips the expensive history backfill during regular scheduled runs', async () => {
+    const { client, rpc } = createAdminClient();
+    const result = await runPersonalAnalysisWorker({
+      adminClient: client,
+      config: enabledConfig({ backfillEnabled: false }),
+      leaseId: LEASE_ID,
+    });
+
+    expect(rpc.mock.calls[0]).toEqual([
+      'claim_personal_analysis_jobs',
+      {
+        p_lease_id: LEASE_ID,
+        p_limit: 1,
+        p_lease_seconds: 50,
+      },
+    ]);
+    expect(rpc).not.toHaveBeenCalledWith(
+      'enqueue_personal_analysis_backfill',
+      expect.any(Object)
+    );
+    expect(result.backfill).toEqual({
+      processedUsers: 0,
+      insertedOwnerStates: 0,
+      insertedScopeStates: 0,
+      hasMore: false,
+    });
   });
 
   it('loads one user once and publishes owner plus every matching account scope', async () => {

--- a/api/_lib/personalAnalysisWorker.js
+++ b/api/_lib/personalAnalysisWorker.js
@@ -82,6 +82,10 @@ function parseInteger(value, defaultValue, { min = 1, max = Number.MAX_SAFE_INTE
 export function getPersonalAnalysisWorkerConfigFromEnv(env = readEnvironment()) {
   return {
     enabled: parseBoolean(env.PERSONAL_ANALYSIS_WORKER_ENABLED, false),
+    backfillEnabled: parseBoolean(
+      env.PERSONAL_ANALYSIS_WORKER_BACKFILL_ENABLED,
+      false
+    ),
     batchSize: parseInteger(env.PERSONAL_ANALYSIS_WORKER_BATCH_SIZE, 1, { min: 1, max: 5 }),
     backfillBatchSize: parseInteger(
       env.PERSONAL_ANALYSIS_WORKER_BACKFILL_BATCH_SIZE,
@@ -117,6 +121,9 @@ function normalizeConfig(config) {
 
   return {
     enabled: typeof config.enabled === 'boolean' ? config.enabled : defaults.enabled,
+    backfillEnabled: typeof config.backfillEnabled === 'boolean'
+      ? config.backfillEnabled
+      : defaults.backfillEnabled,
     batchSize: parseInteger(config.batchSize, defaults.batchSize, { min: 1, max: 5 }),
     backfillBatchSize: parseInteger(
       config.backfillBatchSize,
@@ -432,10 +439,12 @@ export async function runPersonalAnalysisWorker({
     };
   }
 
-  const backfill = await callRpc(adminClient, 'enqueue_personal_analysis_backfill', {
-    p_after_user_id: null,
-    p_limit: workerConfig.backfillBatchSize,
-  });
+  const backfill = workerConfig.backfillEnabled
+    ? await callRpc(adminClient, 'enqueue_personal_analysis_backfill', {
+      p_after_user_id: null,
+      p_limit: workerConfig.backfillBatchSize,
+    })
+    : null;
   const activeLeaseId = leaseId || createLeaseId();
   const claimed = await callRpc(adminClient, 'claim_personal_analysis_jobs', {
     p_lease_id: activeLeaseId,

--- a/docs/PERSONAL_ANALYSIS_WORKER.md
+++ b/docs/PERSONAL_ANALYSIS_WORKER.md
@@ -23,10 +23,15 @@ GitHub 的 Scheduled Workflow 只从默认分支读取。Workflow 合并到 `mai
 ```text
 PERSONAL_ANALYSIS_WORKER_ENABLED=true
 PERSONAL_ANALYSIS_WORKER_SECRET=<随机高强度密钥>
+PERSONAL_ANALYSIS_WORKER_BACKFILL_ENABLED=false
 ```
 
 `SUPABASE_SECRET_KEY`（或兼容的 service role key）也必须可用。单次任务默认只
 领取一个队列作业，以避免超过 Vercel 函数执行时限。
+
+常规计划任务必须保持 `PERSONAL_ANALYSIS_WORKER_BACKFILL_ENABLED=false`，避免
+每 5 分钟重复扫描全量历史。新写入会由数据库触发器自动创建或标脏队列状态。
+历史数据的一次性全量回填应在维护窗口临时开启该变量，完成后立即关闭。
 
 ### GitHub Repository Actions Secret
 


### PR DESCRIPTION
## Summary

- 常规个人分析 Worker 默认跳过全量历史 backfill，直接领取已有 owner/scope 队列
- 保留 `PERSONAL_ANALYSIS_WORKER_BACKFILL_ENABLED=true` 作为维护窗口的一次性回填开关
- 修复生产 `enqueue_personal_analysis_backfill` 因全表查询触发 `57014 statement timeout`、导致 Actions 连续 HTTP 500

## Test plan

- [x] Worker、路由和调度合同测试（15 tests）
- [x] 本地直接连接生产队列验证：claimedOwner=1、claimedScope=1、succeeded=2、failed=0
- [x] `PERSONAL_ANALYSIS_WORKER_BACKFILL_ENABLED=false` 已配置到 Vercel Production