### PR TITLE
fix: 修复个人分析加载与队列饥饿

### DIFF
--- a/.github/scripts/run-personal-analysis-worker.mjs
+++ b/.github/scripts/run-personal-analysis-worker.mjs
@@ -1,0 +1,127 @@
+const workerUrl = String(process.env.WORKER_URL || '').trim();
+const workerSecret = String(process.env.WORKER_SECRET || '').trim();
+const protectionBypassSecret = String(process.env.VERCEL_AUTOMATION_BYPASS_SECRET || '').trim();
+const maxBatches = Math.min(8, Math.max(1, Number.parseInt(process.env.WORKER_MAX_BATCHES || '4', 10) || 4));
+
+function validateConfiguration() {
+  if (!workerSecret) {
+    throw new Error('Repository secret PERSONAL_ANALYSIS_WORKER_SECRET is not configured');
+  }
+
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(workerUrl);
+  } catch {
+    throw new Error('Repository variable PERSONAL_ANALYSIS_WORKER_URL is invalid');
+  }
+  if (parsedUrl.protocol !== 'https:') {
+    throw new Error('PERSONAL_ANALYSIS_WORKER_URL must use HTTPS');
+  }
+  if (!parsedUrl.hostname.endsWith('.vercel.app')) {
+    throw new Error(
+      'PERSONAL_ANALYSIS_WORKER_URL must be an immutable Vercel deployment URL, not the frontend production domain'
+    );
+  }
+  if (parsedUrl.pathname !== '/api/personal-analysis-worker') {
+    throw new Error('PERSONAL_ANALYSIS_WORKER_URL must target /api/personal-analysis-worker');
+  }
+}
+
+function summarizeResult(payload) {
+  const result = payload?.result || {};
+  const stats = result?.stats || {};
+  return {
+    code: result?.code || null,
+    claimedOwner: Number(stats.claimedOwner || 0),
+    claimedScope: Number(stats.claimedScope || 0),
+    succeeded: Number(stats.succeeded || 0),
+    stale: Number(stats.stale || 0),
+    failed: Number(stats.failed || 0),
+    backfillHasMore: Boolean(result?.backfill?.hasMore),
+  };
+}
+
+function assertSuccessfulPayload(payload) {
+  const result = payload?.result || {};
+  if (payload?.success !== true || payload?.partial === true || result?.ok === false || result?.skipped === true) {
+    throw new Error('Worker returned a partial, failed, or skipped result');
+  }
+}
+
+async function callWorker() {
+  const headers = {
+    Authorization: `Bearer ${workerSecret}`,
+    'Content-Type': 'application/json',
+  };
+  if (protectionBypassSecret) {
+    headers['x-vercel-protection-bypass'] = protectionBypassSecret;
+  }
+
+  const response = await fetch(workerUrl, {
+    method: 'POST',
+    headers,
+    signal: AbortSignal.timeout(75_000),
+  });
+  const responseText = await response.text();
+  let payload = null;
+  try {
+    payload = JSON.parse(responseText);
+  } catch {
+    throw new Error(`Worker returned non-JSON HTTP ${response.status}`);
+  }
+  if (!response.ok) {
+    throw new Error(`Worker returned HTTP ${response.status}`);
+  }
+  assertSuccessfulPayload(payload);
+  return summarizeResult(payload);
+}
+
+async function callWorkerWithRetry(batchNumber) {
+  let lastError;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      return await callWorker();
+    } catch (error) {
+      lastError = error;
+      console.warn(`Worker batch ${batchNumber}/${maxBatches}, attempt ${attempt}/3 failed: ${error.message}`);
+      if (attempt < 3) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 10_000));
+      }
+    }
+  }
+  throw lastError || new Error('Worker failed after 3 attempts');
+}
+
+async function main() {
+  validateConfiguration();
+  const totals = {
+    batches: 0,
+    claimedOwner: 0,
+    claimedScope: 0,
+    succeeded: 0,
+    stale: 0,
+    failed: 0,
+  };
+
+  for (let batchNumber = 1; batchNumber <= maxBatches; batchNumber += 1) {
+    const summary = await callWorkerWithRetry(batchNumber);
+    totals.batches += 1;
+    totals.claimedOwner += summary.claimedOwner;
+    totals.claimedScope += summary.claimedScope;
+    totals.succeeded += summary.succeeded;
+    totals.stale += summary.stale;
+    totals.failed += summary.failed;
+    console.log(JSON.stringify({ batch: batchNumber, ...summary }));
+
+    if (summary.claimedOwner + summary.claimedScope === 0) {
+      break;
+    }
+  }
+
+  console.log(JSON.stringify({ completed: true, totals }));
+}
+
+main().catch((error) => {
+  console.error(`Personal analysis worker failed: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Unit test suite
         run: npm run test:unit
 
+      - name: Personal analysis queue SQL behavior
+        run: npm run test:personal-analysis-queue
+
       - name: Prepare cn-font-split FFI runtime
         # cn-font-split 7.4.1 的 postinstall 依赖 ungh.cc 查询最新版本，该服务不稳定；
         # 显式固定下载 7.6.8 的 libffi 二进制，避免字体构建因共享库缺失失败。

--- a/.github/workflows/personal-analysis-worker.yml
+++ b/.github/workflows/personal-analysis-worker.yml
@@ -15,12 +15,22 @@ concurrency:
 jobs:
   run-worker:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 12
     env:
-      WORKER_URL: ${{ vars.PERSONAL_ANALYSIS_WORKER_URL || 'https://ef-gacha.mogujun.icu/api/personal-analysis-worker' }}
+      WORKER_URL: ${{ vars.PERSONAL_ANALYSIS_WORKER_URL }}
       WORKER_SECRET: ${{ secrets.PERSONAL_ANALYSIS_WORKER_SECRET }}
+      WORKER_MAX_BATCHES: ${{ vars.PERSONAL_ANALYSIS_WORKER_MAX_BATCHES || '4' }}
+      VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
     steps:
+      - name: Checkout worker runner
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       - name: Validate worker configuration
         shell: bash
         run: |
@@ -33,67 +43,10 @@ jobs:
             echo "::error::PERSONAL_ANALYSIS_WORKER_URL must use HTTPS."
             exit 1
           fi
+          if [[ ! "${WORKER_URL}" =~ \.vercel\.app/api/personal-analysis-worker$ ]]; then
+            echo "::error::PERSONAL_ANALYSIS_WORKER_URL must use an immutable Vercel deployment URL."
+            exit 1
+          fi
 
       - name: Run personal analysis worker
-        shell: bash
-        run: |
-          set -euo pipefail
-          response_file="$(mktemp)"
-          trap 'rm -f "${response_file}"' EXIT
-
-          for attempt in 1 2 3; do
-            http_code="$(
-              curl \
-                --silent \
-                --show-error \
-                --request POST \
-                --connect-timeout 15 \
-                --max-time 75 \
-                --output "${response_file}" \
-                --write-out '%{http_code}' \
-                --header "Authorization: Bearer ${WORKER_SECRET}" \
-                --header 'Content-Type: application/json' \
-                "${WORKER_URL}" \
-                || true
-            )"
-
-            if [[ "${http_code}" =~ ^2[0-9][0-9]$ ]]; then
-              if node --input-type=module - "${response_file}" <<'NODE'
-          import { readFile } from 'node:fs/promises';
-
-          const responsePath = process.argv[2];
-          const payload = JSON.parse(await readFile(responsePath, 'utf8'));
-          const result = payload?.result || {};
-          if (
-            payload?.success !== true
-            || payload?.partial === true
-            || result?.ok === false
-            || result?.skipped === true
-          ) {
-            process.exit(1);
-          }
-
-          const stats = result?.stats || {};
-          console.log(JSON.stringify({
-            code: result?.code || null,
-            claimedOwner: Number(stats.claimedOwner || 0),
-            claimedScope: Number(stats.claimedScope || 0),
-            succeeded: Number(stats.succeeded || 0),
-            stale: Number(stats.stale || 0),
-            failed: Number(stats.failed || 0),
-            backfillHasMore: Boolean(result?.backfill?.hasMore),
-          }));
-          NODE
-              then
-                exit 0
-              fi
-            fi
-
-            echo "::warning::Worker attempt ${attempt}/3 failed with HTTP ${http_code:-transport-error}."
-            if [[ "${attempt}" -lt 3 ]]; then
-              sleep "$((attempt * 10))"
-            fi
-          done
-
-          echo "::error::Personal analysis worker failed after 3 attempts."
-          exit 1
+        run: node .github/scripts/run-personal-analysis-worker.mjs

--- a/api/__tests__/accountGachaData.test.js
+++ b/api/__tests__/accountGachaData.test.js
@@ -292,7 +292,11 @@ function createAdminClient() {
       computed_at: '2026-08-04T12:00:00.000Z',
       payload: {
         defaultAccountKey: 'game-1::server:2',
-        accounts: [{ accountKey: 'game-1::server:2' }],
+        accounts: [{
+          accountKey: 'game-1::server:2',
+          gameUid: 'game-1',
+          serverScope: '2',
+        }],
         summary: { total: 1 },
       },
     },
@@ -332,6 +336,16 @@ function createAdminClient() {
     })),
     rpc: vi.fn(async (functionName, params = {}) => {
       state.rpcCalls.push({ functionName, params });
+      if (functionName === 'prioritize_personal_analysis_jobs') {
+        return {
+          data: {
+            queued: true,
+            ownerRows: 1,
+            scopeRows: 1,
+          },
+          error: null,
+        };
+      }
       if (functionName === 'delete_history_records_controlled') {
         return {
           data: {
@@ -499,7 +513,7 @@ describe('/api/account-gacha-data', () => {
     }), res);
 
     expect(res.statusCode).toBe(202);
-    expect(res.headers['Retry-After']).toBe('10');
+    expect(res.headers['Retry-After']).toBe('60');
     expect(res.body).toMatchObject({
       success: true,
       mode: 'analysis',
@@ -508,6 +522,8 @@ describe('/api/account-gacha-data', () => {
         ownerId: 'user-1',
         rawIncluded: false,
         verifiedEmpty: false,
+        retryAfterSeconds: 60,
+        updateQueued: true,
       },
       owner: null,
       scope: null,
@@ -516,6 +532,16 @@ describe('/api/account-gacha-data', () => {
     const historyReads = adminClient.__state.selectCalls.filter((call) => call.table === 'history');
     expect(historyReads).toHaveLength(0);
     expect(adminClient.from).toHaveBeenCalledWith('history');
+    expect(adminClient.__state.rpcCalls).toContainEqual({
+      functionName: 'prioritize_personal_analysis_jobs',
+      params: {
+        p_user_id: 'user-1',
+        p_scope_game_uid: null,
+        p_server_scope: null,
+        p_force_owner: true,
+        p_force_scope: false,
+      },
+    });
   });
 
   it('only reports verified empty after a bounded history existence check', async () => {
@@ -545,6 +571,40 @@ describe('/api/account-gacha-data', () => {
     });
   });
 
+  it('prioritizes the selected scope when its account snapshot is missing', async () => {
+    const adminClient = createAdminClient();
+    delete adminClient.__state.accountSnapshots['game-1::server:2'];
+    mocks.getSupabaseAdminClient.mockReturnValue(adminClient);
+    const res = createJsonResponseRecorder();
+
+    await accountGachaDataHandler(createRequest({
+      url: '/api/account-gacha-data?mode=analysis&accountKey=game-1%3A%3Aserver%3A2',
+    }), res);
+
+    expect(res.statusCode).toBe(202);
+    expect(res.headers['Retry-After']).toBe('60');
+    expect(res.body).toMatchObject({
+      availability: 'building',
+      meta: {
+        accountKey: 'game-1::server:2',
+        retryAfterSeconds: 60,
+        updateQueued: true,
+      },
+      owner: expect.any(Object),
+      scope: null,
+    });
+    expect(adminClient.__state.rpcCalls).toContainEqual({
+      functionName: 'prioritize_personal_analysis_jobs',
+      params: {
+        p_user_id: 'user-1',
+        p_scope_game_uid: 'game-1',
+        p_server_scope: '2',
+        p_force_owner: false,
+        p_force_scope: true,
+      },
+    });
+  });
+
   it('serves the last analysis as stale when its owner revision is behind', async () => {
     const adminClient = createAdminClient();
     adminClient.__state.ownerState.history_revision = 8;
@@ -561,8 +621,20 @@ describe('/api/account-gacha-data', () => {
       meta: {
         revision: '8',
         ownerSnapshotRevision: '7',
+        retryAfterSeconds: 60,
+        updateQueued: true,
       },
       warnings: [{ code: 'personal_analysis_owner_stale' }],
+    });
+    expect(adminClient.__state.rpcCalls).toContainEqual({
+      functionName: 'prioritize_personal_analysis_jobs',
+      params: {
+        p_user_id: 'user-1',
+        p_scope_game_uid: 'game-1',
+        p_server_scope: '2',
+        p_force_owner: false,
+        p_force_scope: false,
+      },
     });
   });
 

--- a/api/__tests__/personalAnalysisWorker.test.js
+++ b/api/__tests__/personalAnalysisWorker.test.js
@@ -78,6 +78,7 @@ function createAdminClient({
     eq(column, value) { this.filters.push(['eq', column, value]); return this; }
     gt(column, value) { this.filters.push(['gt', column, value]); return this; }
     in(column, values) { this.filters.push(['in', column, values]); return this; }
+    or(value) { this.filters.push(['or', value]); return this; }
     order() { return this; }
     limit(value) { this.limitValue = value; return this; }
     range(from, to) { this.rangeValue = [from, to]; return this; }
@@ -95,6 +96,9 @@ function createAdminClient({
         if (operator === 'eq') data = data.filter((row) => row?.[column] === value);
         if (operator === 'gt') data = data.filter((row) => row?.[column] > value);
         if (operator === 'in') data = data.filter((row) => value.includes(row?.[column]));
+        if (operator === 'or' && column === 'game_uid.is.null,game_uid.eq.') {
+          data = data.filter((row) => row?.game_uid == null || row?.game_uid === '');
+        }
       });
       if (this.table === 'history') {
         data = [...data].sort((left, right) => Number(left.id) - Number(right.id));
@@ -402,6 +406,64 @@ describe('personal analysis worker', () => {
     ));
     expect(publishCall[1].p_snapshots).toEqual([]);
     expect(result.stats.succeeded).toBe(1);
+  });
+
+  it('does not mark a scope fresh when legacy identity folding drops live history', async () => {
+    const { client, rpc } = createAdminClient({
+      claimed: {
+        ownerJobs: [],
+        scopeJobs: [{
+          userId: USER_ID,
+          scopeGameUid: 'legacy',
+          serverScope: '9',
+          historyRevision: '7',
+          analysisSchemaVersion: 1,
+        }],
+      },
+      history: [
+        createHistoryRow({
+          id: 1,
+          record_id: 'legacy-9',
+          game_uid: null,
+          server_scope: '9',
+          server_id: '9',
+          timestamp: '2026-08-01T00:00:00.000Z',
+        }),
+        createHistoryRow({
+          id: 2,
+          record_id: 'legacy-10',
+          game_uid: null,
+          server_scope: '10',
+          server_id: '10',
+          timestamp: '2026-08-02T00:00:00.000Z',
+        }),
+      ],
+      pools: [createPoolRow()],
+    });
+
+    const result = await runPersonalAnalysisWorker({
+      adminClient: client,
+      config: enabledConfig(),
+      leaseId: LEASE_ID,
+    });
+
+    expect(result.stats).toMatchObject({ succeeded: 0, failed: 1 });
+    expect(result.results).toContainEqual({
+      kind: 'scope',
+      status: 'failed',
+      code: 'personal_analysis_scope_identity_mismatch',
+    });
+    expect(rpc).not.toHaveBeenCalledWith(
+      'publish_personal_analysis_scope_snapshots',
+      expect.any(Object)
+    );
+    expect(rpc).toHaveBeenCalledWith(
+      'fail_personal_analysis_job',
+      expect.objectContaining({
+        p_kind: 'scope',
+        p_error_code: 'personal_analysis_scope_identity_mismatch',
+      })
+    );
   });
 
   it('counts a false publish as stale instead of failed', async () => {

--- a/api/__tests__/personalAnalysisWorkerSchedule.test.js
+++ b/api/__tests__/personalAnalysisWorkerSchedule.test.js
@@ -23,18 +23,29 @@ describe('personal analysis worker production schedule', () => {
   });
 
   it('schedules an authenticated and validated GitHub Actions worker call', async () => {
-    const workflow = await readFile(
-      path.join(projectRoot, '.github', 'workflows', 'personal-analysis-worker.yml'),
-      'utf8'
-    );
+    const [workflow, runner] = await Promise.all([
+      readFile(
+        path.join(projectRoot, '.github', 'workflows', 'personal-analysis-worker.yml'),
+        'utf8'
+      ),
+      readFile(
+        path.join(projectRoot, '.github', 'scripts', 'run-personal-analysis-worker.mjs'),
+        'utf8'
+      ),
+    ]);
 
     expect(workflow).toContain("cron: '*/5 * * * *'");
     expect(workflow).toContain('workflow_dispatch:');
     expect(workflow).toContain('secrets.PERSONAL_ANALYSIS_WORKER_SECRET');
     expect(workflow).toContain('/api/personal-analysis-worker');
-    expect(workflow).toContain('Authorization: Bearer ${WORKER_SECRET}');
-    expect(workflow).toContain('result?.skipped === true');
-    expect(workflow).toContain('payload?.partial === true');
-    expect(workflow).toContain('for attempt in 1 2 3');
+    expect(workflow).not.toContain('ef-gacha.mogujun.icu');
+    expect(workflow).toContain('immutable Vercel deployment URL');
+    expect(workflow).toContain('run-personal-analysis-worker.mjs');
+    expect(runner).toContain('Authorization: `Bearer ${workerSecret}`');
+    expect(runner).toContain('result?.skipped === true');
+    expect(runner).toContain('payload?.partial === true');
+    expect(runner).toContain('attempt <= 3');
+    expect(runner).toContain('batchNumber <= maxBatches');
+    expect(runner).toContain("headers['x-vercel-protection-bypass']");
   });
 });

--- a/api/_lib/personalAnalysisWorker.js
+++ b/api/_lib/personalAnalysisWorker.js
@@ -347,6 +347,21 @@ function buildFailedResult(job, errorCode) {
   };
 }
 
+async function hasHistoryForClaimedScope(adminClient, job) {
+  let query = adminClient
+    .from('history')
+    .select('id')
+    .eq('user_id', job.userId)
+    .eq('server_scope', job.serverScope)
+    .limit(1);
+  query = job.scopeGameUid === 'legacy'
+    ? query.or('game_uid.is.null,game_uid.eq.')
+    : query.eq('game_uid', job.scopeGameUid);
+  const { data, error } = await query;
+  if (error) throw error;
+  return Array.isArray(data) && data.length > 0;
+}
+
 async function publishJob(adminClient, job, model, leaseId) {
   try {
     let published;
@@ -368,6 +383,13 @@ async function publishJob(adminClient, job, model, leaseId) {
           scopeKey: scope.scopeKey,
           payload: scope.payload,
         }));
+      if (snapshots.length === 0 && await hasHistoryForClaimedScope(adminClient, job)) {
+        const scopeMismatchError = new Error(
+          'Claimed scope still has history but produced no analysis snapshots'
+        );
+        scopeMismatchError.code = 'personal_analysis_scope_identity_mismatch';
+        throw scopeMismatchError;
+      }
       published = await callRpc(adminClient, 'publish_personal_analysis_scope_snapshots', {
         p_user_id: job.userId,
         p_scope_game_uid: job.scopeGameUid,
@@ -502,6 +524,7 @@ export const __internal = {
   HISTORY_FIELDS,
   POOL_FIELDS,
   formatPoolRow,
+  hasHistoryForClaimedScope,
   loadHistory,
   normalizeErrorCode,
 };

--- a/api/_routes/root/account-gacha-data.js
+++ b/api/_routes/root/account-gacha-data.js
@@ -379,6 +379,39 @@ function isMissingPersonalAnalysisInfrastructureError(error) {
     );
 }
 
+function isMissingPersonalAnalysisPriorityRpcError(error) {
+  const code = String(error?.code || '').trim();
+  const message = String(error?.message || '').toLowerCase();
+  return code === '42883'
+    || code === 'PGRST202'
+    || message.includes('prioritize_personal_analysis_jobs') && (
+      message.includes('does not exist')
+      || message.includes('schema cache')
+      || message.includes('could not find')
+    );
+}
+
+async function prioritizePersonalAnalysisJobs(dbClient, userId, {
+  scope = null,
+  forceOwner = false,
+  forceScope = false,
+} = {}) {
+  if (!dbClient?.rpc || !userId) return false;
+
+  const { data, error } = await dbClient.rpc('prioritize_personal_analysis_jobs', {
+    p_user_id: userId,
+    p_scope_game_uid: scope?.gameUid || null,
+    p_server_scope: scope?.serverScope || null,
+    p_force_owner: Boolean(forceOwner),
+    p_force_scope: Boolean(forceScope),
+  });
+  if (error) {
+    if (isMissingPersonalAnalysisPriorityRpcError(error)) return false;
+    throw error;
+  }
+  return data?.queued === true;
+}
+
 async function loadPersonalAnalysisScopeState(dbClient, userId, scope) {
   const { data, error } = await dbClient
     .from('personal_analysis_scope_state')
@@ -660,7 +693,11 @@ async function handleLoadPersonalAnalysis(url, res, dbClient, authResult) {
       return;
     }
 
-    res.setHeader('Retry-After', '10');
+    const updateQueued = await prioritizePersonalAnalysisJobs(dbClient, userId, {
+      forceOwner: true,
+    });
+
+    res.setHeader('Retry-After', '60');
     res.status(202).json({
       success: true,
       mode: 'analysis',
@@ -672,7 +709,8 @@ async function handleLoadPersonalAnalysis(url, res, dbClient, authResult) {
         rawIncluded: false,
         verifiedEmpty: false,
         revision: ownerState?.historyRevision || null,
-        retryAfterSeconds: 10,
+        retryAfterSeconds: 60,
+        updateQueued,
       },
       owner: null,
       scope: null,
@@ -736,7 +774,11 @@ async function handleLoadPersonalAnalysis(url, res, dbClient, authResult) {
   ]);
 
   if (accountKey && !accountSnapshot) {
-    res.setHeader('Retry-After', '10');
+    const updateQueued = await prioritizePersonalAnalysisJobs(dbClient, userId, {
+      scope: manifestScope,
+      forceScope: true,
+    });
+    res.setHeader('Retry-After', '60');
     res.status(202).json({
       success: true,
       mode: 'analysis',
@@ -749,7 +791,8 @@ async function handleLoadPersonalAnalysis(url, res, dbClient, authResult) {
         verifiedEmpty: false,
         revision: ownerState?.historyRevision || ownerSnapshot.inputRevision,
         accountKey,
-        retryAfterSeconds: 10,
+        retryAfterSeconds: 60,
+        updateQueued,
       },
       owner: ownerSnapshot.payload,
       scope: null,
@@ -788,6 +831,17 @@ async function handleLoadPersonalAnalysis(url, res, dbClient, authResult) {
   if (!scopeFresh) {
     warnings.push({ code: 'personal_analysis_scope_stale' });
   }
+  const queueScope = manifestScope?.gameUid && manifestScope?.serverScope
+    ? manifestScope
+    : accountSnapshot ? {
+      gameUid: accountSnapshot.sourceGameUid,
+      serverScope: accountSnapshot.sourceServerScope,
+    } : null;
+  const updateQueued = availability === 'stale'
+    ? await prioritizePersonalAnalysisJobs(dbClient, userId, {
+      scope: queueScope,
+    })
+    : false;
 
   res.status(200).json({
     success: true,
@@ -807,6 +861,8 @@ async function handleLoadPersonalAnalysis(url, res, dbClient, authResult) {
       generatedAt: accountSnapshot?.computedAt || ownerSnapshot.computedAt,
       viewKey: viewKey || null,
       locale,
+      retryAfterSeconds: availability === 'stale' ? 60 : null,
+      updateQueued,
     },
     owner: ownerSnapshot.payload,
     scope: accountSnapshot?.payload || null,
@@ -2153,6 +2209,7 @@ export const __internal = {
   loadProjectedPersonalAnalysisAccountSnapshot,
   loadPersonalAnalysisSnapshot,
   loadPersonalAnalysisScopeState,
+  prioritizePersonalAnalysisJobs,
   readHistoryPageScope,
   shouldUseTransientPersonalAnalysis,
 };

--- a/docs/PERSONAL_ANALYSIS_WORKER.md
+++ b/docs/PERSONAL_ANALYSIS_WORKER.md
@@ -8,10 +8,11 @@ GitHub Actions Scheduled Workflow 调度，不使用 Vercel 高频 Cron，避免
 
 - Workflow：`.github/workflows/personal-analysis-worker.yml`
 - 默认频率：每 5 分钟
-- 默认地址：`https://ef-gacha.mogujun.icu/api/personal-analysis-worker`
+- 地址必须是包含 Worker 的不可变 Vercel Deployment URL
 - 支持在 Actions 页面通过 `workflow_dispatch` 手动执行
 - 同一时间最多执行一个任务，后续触发会等待前一次完成
-- 单次调用失败会重试 3 次，并校验 HTTP 与 Worker JSON 状态
+- 单批调用失败会重试 3 次，并校验 HTTP 与 Worker JSON 状态
+- 每次 Workflow 默认连续处理 4 个用户批次，队列为空时提前结束
 
 GitHub 的 Scheduled Workflow 只从默认分支读取。Workflow 合并到 `main` 后才会
 开始定时执行；GitHub 在高负载时可能延迟计划任务。
@@ -27,13 +28,14 @@ PERSONAL_ANALYSIS_WORKER_BACKFILL_ENABLED=false
 ```
 
 `SUPABASE_SECRET_KEY`（或兼容的 service role key）也必须可用。单次任务默认只
-领取一个队列作业，以避免超过 Vercel 函数执行时限。
+领取一个用户及该用户最多 20 个 scope；Worker 只构建一次该用户模型，再发布
+owner 和 scope，以避免重复读取历史并控制 Vercel 函数时限。
 
 常规计划任务必须保持 `PERSONAL_ANALYSIS_WORKER_BACKFILL_ENABLED=false`，避免
 每 5 分钟重复扫描全量历史。新写入会由数据库触发器自动创建或标脏队列状态。
 历史数据的一次性全量回填应在维护窗口临时开启该变量，完成后立即关闭。
 
-### GitHub Repository Actions Secret
+### GitHub Repository Actions Secret / Variable
 
 在仓库 `Settings → Secrets and variables → Actions` 中添加：
 
@@ -41,13 +43,31 @@ PERSONAL_ANALYSIS_WORKER_BACKFILL_ENABLED=false
 PERSONAL_ANALYSIS_WORKER_SECRET=<与 Vercel 完全相同的值>
 ```
 
-可选 Repository Variable：
+必需 Repository Variable：
 
 ```text
-PERSONAL_ANALYSIS_WORKER_URL=https://你的生产域名/api/personal-analysis-worker
+PERSONAL_ANALYSIS_WORKER_URL=https://具体部署ID.vercel.app/api/personal-analysis-worker
 ```
 
-未设置 URL Variable 时使用主站默认地址。
+不要使用正式前台域名。前台被 promote/rollback 到旧部署时，正式域名可能没有
+Worker 路由，导致计划任务持续 404；不可变 Deployment URL 不会随前台回滚移动。
+
+可选配置：
+
+```text
+PERSONAL_ANALYSIS_WORKER_MAX_BATCHES=4
+VERCEL_AUTOMATION_BYPASS_SECRET=<Deployment Protection bypass secret>
+```
+
+如果该 Deployment 启用了 Vercel Protection，必须把 bypass secret 同时配置为
+GitHub Actions Secret；Workflow 会通过 `x-vercel-protection-bypass` 请求头发送。
+
+## 活跃用户优先级
+
+Migration 177 增加 `priority_requested_at`。分析 API 发现当前用户的 owner/account
+快照缺失或过期时，只能通过 service role RPC 将该用户加入活跃优先队列；浏览器
+无法直接指定其他用户。优先级使用首次排队时间，重复轮询不会刷新时间或绕过失败
+退避，因此不会由高频请求长期霸占 Worker。
 
 ## 验证
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "test:force-refresh-gate": "node scripts/verify-force-refresh-gate.mjs",
     "test:supabase-baseline": "node scripts/verify-supabase-baseline.mjs",
     "test:supabase-baseline:smoke": "node scripts/verify-supabase-baseline-smoke.mjs",
+    "test:personal-analysis-queue": "node scripts/verify-personal-analysis-queue-sql.mjs",
     "test:auth-hardening-phase-a": "node scripts/verify-auth-hardening-phase-a.mjs",
     "test:auth-hardening-phase-cd": "node scripts/verify-auth-hardening-phase-cd.mjs",
     "test:history-batch-delete-guard": "node scripts/verify-history-batch-delete-guard.mjs",

--- a/scripts/verify-personal-analysis-queue-sql.mjs
+++ b/scripts/verify-personal-analysis-queue-sql.mjs
@@ -1,0 +1,253 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const migrationPath = path.join(
+  projectRoot,
+  'supabase',
+  'migrations',
+  '177_prioritize_active_personal_analysis_jobs.sql'
+);
+const containerName = `endfield-personal-analysis-queue-${Date.now()}`;
+const postgresImage = process.env.POSTGRES_TEST_IMAGE || 'postgres:17-alpine';
+
+const BACKLOG_USER = '00000000-0000-4000-8000-000000000001';
+const ACTIVE_USER = '00000000-0000-4000-8000-000000000002';
+const BACKOFF_USER = '00000000-0000-4000-8000-000000000003';
+const FIRST_LEASE = '10000000-0000-4000-8000-000000000001';
+const SECOND_LEASE = '10000000-0000-4000-8000-000000000002';
+
+function runDocker(args, options = {}) {
+  const result = spawnSync('docker', args, {
+    encoding: 'utf8',
+    ...options,
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout || `docker ${args.join(' ')} failed`);
+  }
+  return result.stdout;
+}
+
+function waitForPostgres() {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    const result = spawnSync('docker', ['exec', containerName, 'pg_isready', '-U', 'postgres', '-d', 'postgres'], {
+      encoding: 'utf8',
+    });
+    if (result.status === 0) return;
+    execFileSync(process.execPath, ['-e', 'setTimeout(() => {}, 500)']);
+  }
+  throw new Error('PostgreSQL test container did not become ready');
+}
+
+const setupSql = `
+CREATE ROLE anon;
+CREATE ROLE authenticated;
+CREATE ROLE service_role;
+
+CREATE TABLE public.profiles (
+  id UUID PRIMARY KEY
+);
+
+CREATE TABLE public.history (
+  id BIGSERIAL PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  game_uid TEXT,
+  server_scope TEXT
+);
+
+CREATE OR REPLACE FUNCTION public.normalize_personal_analysis_game_uid(
+  p_user_id UUID,
+  p_game_uid TEXT
+)
+RETURNS TEXT
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT COALESCE(NULLIF(btrim(p_game_uid), ''), 'legacy');
+$$;
+
+CREATE TABLE public.personal_analysis_owner_state (
+  user_id UUID PRIMARY KEY REFERENCES public.profiles(id) ON DELETE CASCADE,
+  history_revision BIGINT NOT NULL DEFAULT 0,
+  snapshot_revision BIGINT NOT NULL DEFAULT -1,
+  dirty_since TIMESTAMPTZ,
+  computed_at TIMESTAMPTZ,
+  analysis_schema_version INTEGER NOT NULL DEFAULT 1,
+  last_error TEXT,
+  lease_id UUID,
+  lease_expires_at TIMESTAMPTZ,
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  next_attempt_at TIMESTAMPTZ,
+  CHECK (snapshot_revision >= -1),
+  CHECK (snapshot_revision <= history_revision)
+);
+
+CREATE TABLE public.personal_analysis_scope_state (
+  user_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  scope_game_uid TEXT NOT NULL,
+  server_scope TEXT NOT NULL,
+  history_revision BIGINT NOT NULL DEFAULT 0,
+  snapshot_revision BIGINT NOT NULL DEFAULT -1,
+  dirty_since TIMESTAMPTZ,
+  computed_at TIMESTAMPTZ,
+  analysis_schema_version INTEGER NOT NULL DEFAULT 1,
+  last_error TEXT,
+  lease_id UUID,
+  lease_expires_at TIMESTAMPTZ,
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  next_attempt_at TIMESTAMPTZ,
+  PRIMARY KEY (user_id, scope_game_uid, server_scope),
+  CHECK (snapshot_revision >= -1),
+  CHECK (snapshot_revision <= history_revision)
+);
+`;
+
+const assertionSql = `
+INSERT INTO public.profiles (id)
+VALUES
+  ('${BACKLOG_USER}'),
+  ('${ACTIVE_USER}'),
+  ('${BACKOFF_USER}');
+
+INSERT INTO public.history (user_id, game_uid, server_scope)
+VALUES
+  ('${BACKLOG_USER}', 'backlog-game', '1'),
+  ('${ACTIVE_USER}', 'active-game', '1'),
+  ('${ACTIVE_USER}', 'active-game', '2'),
+  ('${BACKOFF_USER}', 'backoff-game', '1');
+
+INSERT INTO public.personal_analysis_owner_state (
+  user_id, history_revision, snapshot_revision, dirty_since
+)
+VALUES
+  ('${BACKLOG_USER}', 1, -1, statement_timestamp() - interval '2 days'),
+  ('${ACTIVE_USER}', 1, -1, statement_timestamp() - interval '1 day'),
+  ('${BACKOFF_USER}', 1, -1, statement_timestamp() - interval '3 days');
+
+INSERT INTO public.personal_analysis_scope_state (
+  user_id, scope_game_uid, server_scope, history_revision, snapshot_revision, dirty_since
+)
+VALUES
+  ('${BACKLOG_USER}', 'backlog-game', '1', 1, -1, statement_timestamp() - interval '2 days'),
+  ('${ACTIVE_USER}', 'active-game', '1', 1, -1, statement_timestamp() - interval '1 day'),
+  ('${ACTIVE_USER}', 'active-game', '2', 1, -1, statement_timestamp() - interval '1 day'),
+  ('${BACKOFF_USER}', 'backoff-game', '1', 1, -1, statement_timestamp() - interval '3 days');
+
+UPDATE public.personal_analysis_owner_state
+SET attempt_count = 3,
+    next_attempt_at = statement_timestamp() + interval '1 hour'
+WHERE user_id = '${BACKOFF_USER}';
+
+UPDATE public.personal_analysis_scope_state
+SET attempt_count = 3,
+    next_attempt_at = statement_timestamp() + interval '1 hour'
+WHERE user_id = '${BACKOFF_USER}';
+
+DO $$
+DECLARE
+  v_first_priority TIMESTAMPTZ;
+  v_second_priority TIMESTAMPTZ;
+  v_backoff_at TIMESTAMPTZ;
+  v_scope_backoff_at TIMESTAMPTZ;
+  v_claim JSONB;
+BEGIN
+  PERFORM public.prioritize_personal_analysis_jobs(
+    '${ACTIVE_USER}', NULL, NULL, FALSE, FALSE
+  );
+  SELECT priority_requested_at
+  INTO v_first_priority
+  FROM public.personal_analysis_owner_state
+  WHERE user_id = '${ACTIVE_USER}';
+
+  PERFORM pg_sleep(0.01);
+  PERFORM public.prioritize_personal_analysis_jobs(
+    '${ACTIVE_USER}', NULL, NULL, FALSE, FALSE
+  );
+  SELECT priority_requested_at
+  INTO v_second_priority
+  FROM public.personal_analysis_owner_state
+  WHERE user_id = '${ACTIVE_USER}';
+
+  IF v_first_priority IS NULL OR v_second_priority IS DISTINCT FROM v_first_priority THEN
+    RAISE EXCEPTION 'repeated polling changed active-user FIFO priority';
+  END IF;
+
+  SELECT next_attempt_at
+  INTO v_backoff_at
+  FROM public.personal_analysis_owner_state
+  WHERE user_id = '${BACKOFF_USER}';
+  SELECT next_attempt_at
+  INTO v_scope_backoff_at
+  FROM public.personal_analysis_scope_state
+  WHERE user_id = '${BACKOFF_USER}';
+
+  PERFORM public.prioritize_personal_analysis_jobs(
+    '${BACKOFF_USER}', NULL, NULL, FALSE, FALSE
+  );
+  IF (
+    SELECT attempt_count <> 3 OR next_attempt_at IS DISTINCT FROM v_backoff_at
+    FROM public.personal_analysis_owner_state
+    WHERE user_id = '${BACKOFF_USER}'
+  ) THEN
+    RAISE EXCEPTION 'active prioritization bypassed worker failure backoff';
+  END IF;
+  IF (
+    SELECT attempt_count <> 3 OR next_attempt_at IS DISTINCT FROM v_scope_backoff_at
+    FROM public.personal_analysis_scope_state
+    WHERE user_id = '${BACKOFF_USER}'
+  ) THEN
+    RAISE EXCEPTION 'active prioritization bypassed scope failure backoff';
+  END IF;
+
+  v_claim := public.claim_personal_analysis_jobs('${FIRST_LEASE}', 1, 50);
+  IF v_claim #>> '{ownerJobs,0,userId}' <> '${ACTIVE_USER}' THEN
+    RAISE EXCEPTION 'active user was not claimed before historical backlog: %', v_claim;
+  END IF;
+  IF jsonb_array_length(v_claim -> 'scopeJobs') <> 2 THEN
+    RAISE EXCEPTION 'all active-user scopes were not claimed together: %', v_claim;
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_claim -> 'scopeJobs') AS scope_job
+    WHERE scope_job ->> 'userId' <> '${ACTIVE_USER}'
+  ) THEN
+    RAISE EXCEPTION 'scope claim crossed the selected user boundary: %', v_claim;
+  END IF;
+
+  v_claim := public.claim_personal_analysis_jobs('${SECOND_LEASE}', 1, 50);
+  IF v_claim #>> '{ownerJobs,0,userId}' <> '${BACKLOG_USER}' THEN
+    RAISE EXCEPTION 'future-backoff user was claimed before due backlog: %', v_claim;
+  END IF;
+END;
+$$;
+`;
+
+try {
+  const migrationSql = await readFile(migrationPath, 'utf8');
+  runDocker([
+    'run',
+    '--detach',
+    '--rm',
+    '--name',
+    containerName,
+    '--env',
+    'POSTGRES_PASSWORD=personal-analysis-test',
+    postgresImage,
+  ]);
+  waitForPostgres();
+  runDocker(['exec', '-i', containerName, 'psql', '-X', '-q', '-v', 'ON_ERROR_STOP=1', '-U', 'postgres'], {
+    input: `${setupSql}\n${migrationSql}\n${assertionSql}`,
+  });
+  console.log('[verify-personal-analysis-queue-sql] OK');
+  console.log(`- image: ${postgresImage}`);
+  console.log('- active users preserve FIFO priority');
+  console.log('- failed jobs preserve next-attempt backoff');
+  console.log('- one user owner and all scopes are claimed together');
+} finally {
+  spawnSync('docker', ['rm', '--force', containerName], {
+    encoding: 'utf8',
+    stdio: 'ignore',
+  });
+}

--- a/scripts/verify-personal-analysis-queue-sql.mjs
+++ b/scripts/verify-personal-analysis-queue-sql.mjs
@@ -31,11 +31,24 @@ function runDocker(args, options = {}) {
 }
 
 function waitForPostgres() {
-  for (let attempt = 0; attempt < 30; attempt += 1) {
-    const result = spawnSync('docker', ['exec', containerName, 'pg_isready', '-U', 'postgres', '-d', 'postgres'], {
-      encoding: 'utf8',
-    });
-    if (result.status === 0) return;
+  let successStreak = 0;
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const result = spawnSync(
+      'docker',
+      [
+        'exec', containerName,
+        'psql', '-X', '-qAt', '-v', 'ON_ERROR_STOP=1',
+        '-U', 'postgres', '-d', 'postgres',
+        '-c', 'SELECT 1',
+      ],
+      { encoding: 'utf8' }
+    );
+    successStreak = result.status === 0 && result.stdout.trim() === '1'
+      ? successStreak + 1
+      : 0;
+    // The official image briefly exposes a temporary init server before
+    // restarting Postgres. Consecutive real queries avoid that socket race.
+    if (successStreak >= 3) return;
     execFileSync(process.execPath, ['-e', 'setTimeout(() => {}, 500)']);
   }
   throw new Error('PostgreSQL test container did not become ready');

--- a/src/GachaAnalyzer.jsx
+++ b/src/GachaAnalyzer.jsx
@@ -136,13 +136,16 @@ export default function GachaAnalyzer() {
 
   // 应用初始化 Hook - 处理会话、全局统计、last_seen 更新
   useAppInitialization({ refreshPersonalData, loadPublicPools });
-  const retryPersonalData = useCallback(async () => {
+  const retryPersonalData = useCallback(async (retryOptions = {}) => {
     if (!user?.id) {
       return;
     }
+    const automaticPhase = retryOptions?.automatic
+      ? String(retryOptions.phase || '').trim()
+      : '';
     const result = await refreshPersonalData(user, {
-      kind: 'explicit',
-      reason: 'dashboard_retry',
+      kind: automaticPhase ? `${automaticPhase}-poll` : 'explicit',
+      reason: automaticPhase ? `${automaticPhase}_poll` : 'dashboard_retry',
     });
     if (!result?.ok && !result?.stale) {
       showToast(

--- a/src/components/app/PersonalDataBoundary.jsx
+++ b/src/components/app/PersonalDataBoundary.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react';
 import {
   usePersonalAnalysisStore,
@@ -7,7 +7,16 @@ import {
 import { useI18n } from '../../i18n/index.js';
 import { getPersonalDataErrorPresentation } from '../../utils/personalDataError.js';
 
-function PersonalDataStatusPanel({ kind, message, detail = '', onRetry, retryLabel = '重试' }) {
+const AUTO_RETRY_DELAYS_SECONDS = Object.freeze([30, 60, 120, 300]);
+
+function PersonalDataStatusPanel({
+  kind,
+  message,
+  detail = '',
+  onRetry,
+  retryLabel = '重试',
+  allowRetryWhileLoading = false,
+}) {
   const isLoading = kind === 'loading' || kind === 'building';
 
   return (
@@ -31,7 +40,7 @@ function PersonalDataStatusPanel({ kind, message, detail = '', onRetry, retryLab
             {detail}
           </p>
         )}
-        {!isLoading && typeof onRetry === 'function' && (
+        {(!isLoading || allowRetryWhileLoading) && typeof onRetry === 'function' && (
           <button
             type="button"
             onClick={onRetry}
@@ -57,33 +66,63 @@ export default function PersonalDataBoundary({ user, onRetry, children }) {
   const phase = usePersonalDataStore((state) => state.phase);
   const hasSnapshot = usePersonalDataStore((state) => state.hasSnapshot);
   const refreshing = usePersonalDataStore((state) => state.refreshing);
+  const activeRequest = usePersonalDataStore((state) => state.activeRequest);
   const error = usePersonalDataStore((state) => state.error);
   const analysisAvailability = usePersonalAnalysisStore((state) => state.availability);
   const analysisMeta = usePersonalAnalysisStore((state) => state.meta);
   const matchesOwner = Boolean(user?.id && ownerId === user.id);
   const errorPresentation = getPersonalDataErrorPresentation(error, { isEnglish });
   const isAnalysisStale = hasSnapshot && analysisAvailability === 'stale' && !error;
+  const retryMode = !hasSnapshot && phase === 'building'
+    ? 'building'
+    : isAnalysisStale ? 'stale' : null;
+  const retryKey = retryMode ? `${ownerId || ''}:${retryMode}` : '';
+  const [autoRetryState, setAutoRetryState] = useState({ key: '', attempt: 0 });
+  const autoRetryAttempt = autoRetryState.key === retryKey
+    ? autoRetryState.attempt
+    : 0;
+  const automaticRetriesExhausted = autoRetryAttempt >= AUTO_RETRY_DELAYS_SECONDS.length;
+
+  const retryManually = () => {
+    setAutoRetryState({ key: retryKey, attempt: 0 });
+    void onRetry?.({ automatic: false, phase: retryMode });
+  };
 
   useEffect(() => {
     if (
       !matchesOwner
-      || hasSnapshot
-      || phase !== 'building'
+      || !retryMode
+      || activeRequest
+      || automaticRetriesExhausted
       || typeof onRetry !== 'function'
     ) {
       return undefined;
     }
 
     const configuredDelay = Number(analysisMeta?.retryAfterSeconds);
-    const retryAfterSeconds = Number.isFinite(configuredDelay)
-      ? Math.min(30, Math.max(2, configuredDelay))
-      : 3;
+    const retryAfterSeconds = Math.max(
+      AUTO_RETRY_DELAYS_SECONDS[autoRetryAttempt],
+      Number.isFinite(configuredDelay) ? Math.max(2, configuredDelay) : 0
+    );
     const timerId = window.setTimeout(() => {
-      onRetry();
+      setAutoRetryState((state) => ({
+        key: retryKey,
+        attempt: state.key === retryKey ? state.attempt + 1 : 1,
+      }));
+      void onRetry({ automatic: true, phase: retryMode });
     }, retryAfterSeconds * 1000);
 
     return () => window.clearTimeout(timerId);
-  }, [analysisMeta?.retryAfterSeconds, hasSnapshot, matchesOwner, onRetry, phase]);
+  }, [
+    activeRequest,
+    analysisMeta?.retryAfterSeconds,
+    autoRetryAttempt,
+    automaticRetriesExhausted,
+    matchesOwner,
+    onRetry,
+    retryKey,
+    retryMode,
+  ]);
 
   if (!user?.id) {
     return children;
@@ -104,9 +143,16 @@ export default function PersonalDataBoundary({ user, onRetry, children }) {
     return (
       <PersonalDataStatusPanel
         kind="building"
-        message={isEnglish
-          ? 'Your statistics are being prepared. This page will retry automatically…'
-          : '正在生成你的统计快照，本页面稍后会自动重试…'}
+        message={automaticRetriesExhausted
+          ? (isEnglish
+            ? 'Your statistics are still queued. You can retry later without keeping this page open.'
+            : '统计快照仍在后台排队，无需停留在本页面，可稍后手动重试。')
+          : (isEnglish
+            ? 'Your statistics are being prepared. This page will retry with a gradual delay…'
+            : '正在生成你的统计快照，本页面将逐步延长重试间隔…')}
+        onRetry={automaticRetriesExhausted ? retryManually : null}
+        retryLabel={isEnglish ? 'Retry now' : '立即重试'}
+        allowRetryWhileLoading={automaticRetriesExhausted}
       />
     );
   }
@@ -146,9 +192,13 @@ export default function PersonalDataBoundary({ user, onRetry, children }) {
                   ? 'Refresh failed. The last successful analysis remains visible.'
                   : '刷新失败，继续显示上次成功读取的分析。')
                 : isAnalysisStale
-                  ? (isEnglish
-                    ? 'Statistics are updating. Showing the previous result.'
-                    : '统计正在更新，当前显示上次结果')
+                  ? (automaticRetriesExhausted
+                    ? (isEnglish
+                      ? 'The previous result remains visible while the update waits in the background.'
+                      : '更新仍在后台排队，当前继续显示上次结果。')
+                    : (isEnglish
+                      ? 'Statistics are updating. Showing the previous result.'
+                      : '统计正在更新，当前显示上次结果'))
                   : (isEnglish ? 'Refreshing in the background…' : '正在后台刷新，当前分析仍可使用…')}
             </span>
             {error && <span>{errorPresentation.message}</span>}
@@ -161,10 +211,11 @@ export default function PersonalDataBoundary({ user, onRetry, children }) {
               </span>
             )}
           </span>
-          {error && typeof onRetry === 'function' && (
+          {(error || (isAnalysisStale && automaticRetriesExhausted))
+            && typeof onRetry === 'function' && (
             <button
               type="button"
-              onClick={onRetry}
+              onClick={error ? onRetry : retryManually}
               className="min-h-9 shrink-0 border border-current px-3 py-1 font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current"
             >
               {isEnglish ? 'Retry' : '重试'}

--- a/src/components/app/__tests__/PersonalDataBoundary.test.jsx
+++ b/src/components/app/__tests__/PersonalDataBoundary.test.jsx
@@ -105,7 +105,7 @@ describe('PersonalDataBoundary', () => {
     expect(screen.queryByText('server detail must not be rendered directly')).toBeNull();
   });
 
-  it('building 阶段不暴露空页面并按服务端时间自动重试', () => {
+  it('building 阶段使用递增退避且达到上限后停止自动重试', () => {
     vi.useFakeTimers();
     const onRetry = vi.fn();
     usePersonalDataStore.setState({
@@ -119,7 +119,7 @@ describe('PersonalDataBoundary', () => {
       ...createPersonalAnalysisInitialState(),
       ownerId: 'user-1',
       availability: 'building',
-      meta: { ownerId: 'user-1', retryAfterSeconds: 1 },
+      meta: { ownerId: 'user-1', retryAfterSeconds: 10 },
     });
 
     render(
@@ -131,10 +131,20 @@ describe('PersonalDataBoundary', () => {
     expect(screen.queryByText('0 抽 暂无卡池数据')).toBeNull();
     expect(screen.getByTestId('personal-data-building')).toBeTruthy();
 
-    act(() => vi.advanceTimersByTime(1999));
+    act(() => vi.advanceTimersByTime(29_999));
     expect(onRetry).not.toHaveBeenCalled();
     act(() => vi.advanceTimersByTime(1));
-    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenNthCalledWith(1, { automatic: true, phase: 'building' });
+
+    act(() => vi.advanceTimersByTime(60_000));
+    act(() => vi.advanceTimersByTime(120_000));
+    act(() => vi.advanceTimersByTime(300_000));
+    expect(onRetry).toHaveBeenCalledTimes(4);
+    expect(screen.getByText('统计快照仍在后台排队，无需停留在本页面，可稍后手动重试。')).toBeTruthy();
+    expect(screen.getByRole('button', { name: '立即重试' })).toBeTruthy();
+
+    act(() => vi.advanceTimersByTime(600_000));
+    expect(onRetry).toHaveBeenCalledTimes(4);
   });
 
   it('analysis stale 且无错误时显示非阻断提示', () => {

--- a/src/mobile/MobileApp.jsx
+++ b/src/mobile/MobileApp.jsx
@@ -32,13 +32,16 @@ function MobileApplicationShell() {
 
   // 通知徽标 Hook - 加载公告与工单等
   useNotificationBadges();
-  const retryPersonalData = useCallback(async () => {
+  const retryPersonalData = useCallback(async (retryOptions = {}) => {
     if (!user?.id) {
       return;
     }
+    const automaticPhase = retryOptions?.automatic
+      ? String(retryOptions.phase || '').trim()
+      : '';
     const result = await refreshPersonalData(user, {
-      kind: 'explicit',
-      reason: 'mobile_retry',
+      kind: automaticPhase ? `${automaticPhase}-poll` : 'explicit',
+      reason: automaticPhase ? `${automaticPhase}_poll` : 'mobile_retry',
     });
     if (!result?.ok && !result?.stale) {
       showToast(result?.error?.message || '个人数据刷新失败', 'error');

--- a/src/services/__tests__/accountGachaDataService.test.js
+++ b/src/services/__tests__/accountGachaDataService.test.js
@@ -157,6 +157,26 @@ describe('accountGachaDataService', () => {
     );
   });
 
+  it('rejects an unknown analysis availability instead of polling forever', async () => {
+    fetchJsonWithTimeout.mockResolvedValue({
+      response: {
+        ok: true,
+        status: 200,
+        headers: { get: vi.fn(() => 'request-invalid-analysis') },
+      },
+      data: {
+        success: true,
+        availability: 'queued-somewhere',
+      },
+    });
+
+    await expect(loadAccountGachaAnalysis()).rejects.toMatchObject({
+      code: 'personal_analysis_response_invalid',
+      status: 200,
+      requestId: 'request-invalid-analysis',
+    });
+  });
+
   it('uses a native Supabase token only when no site session is active', async () => {
     getSameOriginAuthHeaders.mockResolvedValue({
       headers: {

--- a/src/services/accountGachaDataService.js
+++ b/src/services/accountGachaDataService.js
@@ -78,9 +78,19 @@ export async function loadAccountGachaAnalysis({ accountKey = '', viewKey = '', 
     createAccountGachaDataError(data, response, '账号抽卡分析读取失败', 'account_gacha_analysis_load_failed');
   }
 
-  const availability = ['ready', 'stale', 'building', 'empty'].includes(data?.availability)
-    ? data.availability
-    : 'building';
+  const availability = data?.availability;
+  if (!['ready', 'stale', 'building', 'empty'].includes(availability)) {
+    createAccountGachaDataError(
+      {
+        code: 'personal_analysis_response_invalid',
+        error: '账号抽卡分析返回了无法识别的快照状态',
+        requestId: data?.requestId,
+      },
+      response,
+      '账号抽卡分析响应无效',
+      'personal_analysis_response_invalid'
+    );
+  }
 
   return {
     availability,

--- a/src/stores/__tests__/usePersonalDataStore.test.js
+++ b/src/stores/__tests__/usePersonalDataStore.test.js
@@ -74,4 +74,25 @@ describe('usePersonalDataStore.completeRequest', () => {
     expect(usePersonalDataStore.getState().completeRequest(token, snapshot)).toBe(false);
     expect(usePersonalDataStore.getState().hasSnapshot).toBe(false);
   });
+
+  it('building 自动轮询开始时保持 building 而不是退回 loading', () => {
+    const firstToken = beginOwnerRequest();
+    expect(usePersonalDataStore.getState().completeRequest(
+      firstToken,
+      createAnalysisSnapshot('building')
+    )).toBe(true);
+
+    const current = usePersonalDataStore.getState();
+    const pollToken = current.beginRequest({
+      ownerId: current.ownerId,
+      ownerGeneration: current.ownerGeneration,
+      kind: 'building-poll',
+    });
+
+    expect(pollToken).toBeTruthy();
+    expect(usePersonalDataStore.getState()).toMatchObject({
+      phase: 'building',
+      hasSnapshot: false,
+    });
+  });
 });

--- a/src/stores/usePersonalDataStore.js
+++ b/src/stores/usePersonalDataStore.js
@@ -122,10 +122,15 @@ const usePersonalDataStore = create((set, get) => ({
       requestGeneration,
       kind,
     });
+    const preserveBuildingPhase = !current.hasSnapshot
+      && current.phase === 'building'
+      && kind === 'building-poll';
 
     set({
       requestGeneration,
-      phase: current.hasSnapshot ? current.phase : 'loading',
+      phase: current.hasSnapshot
+        ? current.phase
+        : preserveBuildingPhase ? 'building' : 'loading',
       refreshing: current.hasSnapshot,
       error: null,
       activeRequest: token,

--- a/supabase/baseline/000_complete_schema.sql
+++ b/supabase/baseline/000_complete_schema.sql
@@ -5,8 +5,8 @@
 --   1. 此文件由 scripts/generate-supabase-baseline.mjs 自动生成
 --   2. 合并 supabase/archive/migrations/ 与 supabase/migrations/ 中的标准前向迁移
 --   3. 不包含 supabase/manual/ 下的 destructive / rollback / data-backfill 脚本
---   4. 生成时间: 2026-08-24T15:17:19.845Z
---   5. 覆盖范围: archive/001_init_tables.sql -> active/176_harden_aic_saves_and_economy.sql
+--   4. 生成时间: 2026-08-25T07:17:32.528Z
+--   5. 覆盖范围: archive/001_init_tables.sql -> active/177_prioritize_active_personal_analysis_jobs.sql
 -- ============================================
 
 -- >>> BEGIN MIGRATION: archive/001_init_tables.sql
@@ -31904,4 +31904,411 @@ COMMENT ON TABLE public.game_reward_claims IS
 COMMENT ON TABLE public.game_purchase_events IS
   '小游戏商店购买不可变流水，按 idempotency_key 防重复扣费与重复授予。';
 -- <<< END MIGRATION: active/176_harden_aic_saves_and_economy.sql
+
+-- >>> BEGIN MIGRATION: active/177_prioritize_active_personal_analysis_jobs.sql
+-- 177: prioritize active personal-analysis users and claim complete user batches.
+--
+-- The previous global FIFO queue processed one owner and one scope per run.
+-- A historical backfill therefore placed active users behind thousands of
+-- dormant rows, while remaining scopes could starve whenever another owner
+-- job existed. This migration keeps revision-safe leases but chooses users as
+-- the scheduling unit and lets an authenticated API request promote its own
+-- missing/stale read model through a service-role-only RPC.
+
+BEGIN;
+
+ALTER TABLE public.personal_analysis_owner_state
+  ADD COLUMN IF NOT EXISTS priority_requested_at TIMESTAMPTZ;
+
+ALTER TABLE public.personal_analysis_scope_state
+  ADD COLUMN IF NOT EXISTS priority_requested_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_personal_analysis_owner_state_priority
+  ON public.personal_analysis_owner_state (
+    priority_requested_at ASC NULLS LAST,
+    next_attempt_at,
+    dirty_since,
+    user_id
+  )
+  WHERE snapshot_revision < history_revision;
+
+CREATE INDEX IF NOT EXISTS idx_personal_analysis_scope_state_priority
+  ON public.personal_analysis_scope_state (
+    priority_requested_at ASC NULLS LAST,
+    next_attempt_at,
+    dirty_since,
+    user_id,
+    scope_game_uid,
+    server_scope
+  )
+  WHERE snapshot_revision < history_revision;
+
+CREATE OR REPLACE FUNCTION public.clear_personal_analysis_priority_when_fresh()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  IF NEW.snapshot_revision = NEW.history_revision THEN
+    NEW.priority_requested_at := NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS clear_personal_analysis_owner_priority_when_fresh
+  ON public.personal_analysis_owner_state;
+CREATE TRIGGER clear_personal_analysis_owner_priority_when_fresh
+  BEFORE UPDATE OF snapshot_revision, history_revision
+  ON public.personal_analysis_owner_state
+  FOR EACH ROW
+  EXECUTE FUNCTION public.clear_personal_analysis_priority_when_fresh();
+
+DROP TRIGGER IF EXISTS clear_personal_analysis_scope_priority_when_fresh
+  ON public.personal_analysis_scope_state;
+CREATE TRIGGER clear_personal_analysis_scope_priority_when_fresh
+  BEFORE UPDATE OF snapshot_revision, history_revision
+  ON public.personal_analysis_scope_state
+  FOR EACH ROW
+  EXECUTE FUNCTION public.clear_personal_analysis_priority_when_fresh();
+
+CREATE OR REPLACE FUNCTION public.prioritize_personal_analysis_jobs(
+  p_user_id UUID,
+  p_scope_game_uid TEXT DEFAULT NULL,
+  p_server_scope TEXT DEFAULT NULL,
+  p_force_owner BOOLEAN DEFAULT FALSE,
+  p_force_scope BOOLEAN DEFAULT FALSE
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  -- clock_timestamp() changes within a transaction. This preserves FIFO
+  -- ordering even when maintenance code prioritizes several users in one
+  -- transaction; repeated requests still retain their first timestamp below.
+  v_requested_at TIMESTAMPTZ := clock_timestamp();
+  v_game_uid TEXT := NULLIF(btrim(p_scope_game_uid), '');
+  v_server_scope TEXT := NULLIF(btrim(p_server_scope), '');
+  v_owner_rows INTEGER := 0;
+  v_scope_rows INTEGER := 0;
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'personal_analysis_user_id_required';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.history AS history_row
+    WHERE history_row.user_id = p_user_id
+  ) THEN
+    RETURN jsonb_build_object(
+      'queued', FALSE,
+      'ownerRows', 0,
+      'scopeRows', 0
+    );
+  END IF;
+
+  INSERT INTO public.personal_analysis_owner_state (
+    user_id,
+    history_revision,
+    snapshot_revision,
+    dirty_since,
+    analysis_schema_version,
+    priority_requested_at
+  )
+  VALUES (
+    p_user_id,
+    1,
+    -1,
+    v_requested_at,
+    1,
+    v_requested_at
+  )
+  ON CONFLICT (user_id) DO NOTHING;
+
+  INSERT INTO public.personal_analysis_scope_state (
+    user_id,
+    scope_game_uid,
+    server_scope,
+    history_revision,
+    snapshot_revision,
+    dirty_since,
+    analysis_schema_version,
+    priority_requested_at
+  )
+  SELECT DISTINCT
+    history_row.user_id,
+    public.normalize_personal_analysis_game_uid(
+      history_row.user_id,
+      history_row.game_uid
+    ),
+    COALESCE(NULLIF(btrim(history_row.server_scope), ''), 'legacy'),
+    1,
+    -1,
+    v_requested_at,
+    1,
+    v_requested_at
+  FROM public.history AS history_row
+  WHERE history_row.user_id = p_user_id
+    AND (
+      v_game_uid IS NULL
+      OR public.normalize_personal_analysis_game_uid(
+        history_row.user_id,
+        history_row.game_uid
+      ) = v_game_uid
+    )
+    AND (
+      v_server_scope IS NULL
+      OR COALESCE(NULLIF(btrim(history_row.server_scope), ''), 'legacy') = v_server_scope
+    )
+  ON CONFLICT (user_id, scope_game_uid, server_scope) DO NOTHING;
+
+  UPDATE public.personal_analysis_owner_state AS state
+  SET
+    snapshot_revision = CASE
+      WHEN p_force_owner AND state.snapshot_revision = state.history_revision
+        THEN GREATEST(-1, state.history_revision - 1)
+      ELSE state.snapshot_revision
+    END,
+    dirty_since = COALESCE(state.dirty_since, v_requested_at),
+    priority_requested_at = COALESCE(state.priority_requested_at, v_requested_at),
+    lease_id = CASE
+      WHEN state.lease_expires_at <= v_requested_at THEN NULL
+      ELSE state.lease_id
+    END,
+    lease_expires_at = CASE
+      WHEN state.lease_expires_at <= v_requested_at THEN NULL
+      ELSE state.lease_expires_at
+    END
+  WHERE state.user_id = p_user_id
+    AND (
+      state.snapshot_revision < state.history_revision
+      OR p_force_owner
+    );
+  GET DIAGNOSTICS v_owner_rows = ROW_COUNT;
+
+  UPDATE public.personal_analysis_scope_state AS state
+  SET
+    snapshot_revision = CASE
+      WHEN p_force_scope AND state.snapshot_revision = state.history_revision
+        THEN GREATEST(-1, state.history_revision - 1)
+      ELSE state.snapshot_revision
+    END,
+    dirty_since = COALESCE(state.dirty_since, v_requested_at),
+    priority_requested_at = COALESCE(state.priority_requested_at, v_requested_at),
+    lease_id = CASE
+      WHEN state.lease_expires_at <= v_requested_at THEN NULL
+      ELSE state.lease_id
+    END,
+    lease_expires_at = CASE
+      WHEN state.lease_expires_at <= v_requested_at THEN NULL
+      ELSE state.lease_expires_at
+    END
+  WHERE state.user_id = p_user_id
+    AND (v_game_uid IS NULL OR state.scope_game_uid = v_game_uid)
+    AND (v_server_scope IS NULL OR state.server_scope = v_server_scope)
+    AND (
+      state.snapshot_revision < state.history_revision
+      OR p_force_scope
+    );
+  GET DIAGNOSTICS v_scope_rows = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'queued', v_owner_rows > 0 OR v_scope_rows > 0,
+    'ownerRows', v_owner_rows,
+    'scopeRows', v_scope_rows,
+    'requestedAt', v_requested_at
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.prioritize_personal_analysis_jobs(
+  UUID,
+  TEXT,
+  TEXT,
+  BOOLEAN,
+  BOOLEAN
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.prioritize_personal_analysis_jobs(
+  UUID,
+  TEXT,
+  TEXT,
+  BOOLEAN,
+  BOOLEAN
+) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.claim_personal_analysis_jobs(
+  p_lease_id UUID,
+  p_limit INTEGER DEFAULT 1,
+  p_lease_seconds INTEGER DEFAULT 50
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_limit INTEGER := LEAST(GREATEST(COALESCE(p_limit, 1), 1), 5);
+  v_lease_seconds INTEGER := LEAST(
+    GREATEST(COALESCE(p_lease_seconds, 50), 30),
+    55
+  );
+  v_scope_limit_per_user INTEGER := 20;
+  v_user_ids UUID[] := ARRAY[]::UUID[];
+  v_owner_jobs JSONB := '[]'::JSONB;
+  v_scope_jobs JSONB := '[]'::JSONB;
+BEGIN
+  IF p_lease_id IS NULL THEN
+    RAISE EXCEPTION 'personal_analysis_lease_id_required';
+  END IF;
+
+  SELECT COALESCE(array_agg(candidate.user_id ORDER BY candidate.rank), ARRAY[]::UUID[])
+  INTO v_user_ids
+  FROM (
+    SELECT
+      due.user_id,
+      row_number() OVER (
+        ORDER BY
+          (max(due.priority_requested_at) IS NULL),
+          min(due.priority_requested_at) ASC NULLS LAST,
+          min(due.next_attempt_at) NULLS FIRST,
+          min(due.dirty_since) NULLS FIRST,
+          due.user_id
+      ) AS rank
+    FROM (
+      SELECT
+        state.user_id,
+        state.priority_requested_at,
+        state.next_attempt_at,
+        state.dirty_since
+      FROM public.personal_analysis_owner_state AS state
+      WHERE state.snapshot_revision < state.history_revision
+        AND (state.lease_expires_at IS NULL OR state.lease_expires_at <= statement_timestamp())
+        AND (state.next_attempt_at IS NULL OR state.next_attempt_at <= statement_timestamp())
+
+      UNION ALL
+
+      SELECT
+        state.user_id,
+        state.priority_requested_at,
+        state.next_attempt_at,
+        state.dirty_since
+      FROM public.personal_analysis_scope_state AS state
+      WHERE state.snapshot_revision < state.history_revision
+        AND (state.lease_expires_at IS NULL OR state.lease_expires_at <= statement_timestamp())
+        AND (state.next_attempt_at IS NULL OR state.next_attempt_at <= statement_timestamp())
+    ) AS due
+    GROUP BY due.user_id
+    ORDER BY rank
+    LIMIT v_limit
+  ) AS candidate;
+
+  IF COALESCE(array_length(v_user_ids, 1), 0) = 0 THEN
+    RETURN jsonb_build_object(
+      'leaseId', p_lease_id,
+      'leaseSeconds', v_lease_seconds,
+      'ownerJobs', v_owner_jobs,
+      'scopeJobs', v_scope_jobs
+    );
+  END IF;
+
+  WITH claimed AS (
+    UPDATE public.personal_analysis_owner_state AS state
+    SET
+      lease_id = p_lease_id,
+      lease_expires_at = statement_timestamp() + make_interval(secs => v_lease_seconds)
+    WHERE state.user_id = ANY(v_user_ids)
+      AND state.snapshot_revision < state.history_revision
+      AND (state.lease_expires_at IS NULL OR state.lease_expires_at <= statement_timestamp())
+      AND (state.next_attempt_at IS NULL OR state.next_attempt_at <= statement_timestamp())
+    RETURNING
+      state.user_id,
+      state.history_revision,
+      state.analysis_schema_version
+  )
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'kind', 'owner',
+        'userId', claimed.user_id,
+        'historyRevision', claimed.history_revision::TEXT,
+        'analysisSchemaVersion', claimed.analysis_schema_version
+      )
+      ORDER BY claimed.user_id
+    ),
+    '[]'::JSONB
+  )
+  INTO v_owner_jobs
+  FROM claimed;
+
+  WITH ranked AS (
+    SELECT
+      state.user_id,
+      state.scope_game_uid,
+      state.server_scope,
+      row_number() OVER (
+        PARTITION BY state.user_id
+        ORDER BY
+          state.priority_requested_at ASC NULLS LAST,
+          state.next_attempt_at NULLS FIRST,
+          state.dirty_since NULLS FIRST,
+          state.scope_game_uid,
+          state.server_scope
+      ) AS scope_rank
+    FROM public.personal_analysis_scope_state AS state
+    WHERE state.user_id = ANY(v_user_ids)
+      AND state.snapshot_revision < state.history_revision
+      AND (state.lease_expires_at IS NULL OR state.lease_expires_at <= statement_timestamp())
+      AND (state.next_attempt_at IS NULL OR state.next_attempt_at <= statement_timestamp())
+  ),
+  claimed AS (
+    UPDATE public.personal_analysis_scope_state AS state
+    SET
+      lease_id = p_lease_id,
+      lease_expires_at = statement_timestamp() + make_interval(secs => v_lease_seconds)
+    FROM ranked
+    WHERE ranked.scope_rank <= v_scope_limit_per_user
+      AND state.user_id = ranked.user_id
+      AND state.scope_game_uid = ranked.scope_game_uid
+      AND state.server_scope = ranked.server_scope
+      AND state.snapshot_revision < state.history_revision
+      AND (state.lease_expires_at IS NULL OR state.lease_expires_at <= statement_timestamp())
+      AND (state.next_attempt_at IS NULL OR state.next_attempt_at <= statement_timestamp())
+    RETURNING
+      state.user_id,
+      state.scope_game_uid,
+      state.server_scope,
+      state.history_revision,
+      state.analysis_schema_version
+  )
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'kind', 'scope',
+        'userId', claimed.user_id,
+        'scopeGameUid', claimed.scope_game_uid,
+        'serverScope', claimed.server_scope,
+        'historyRevision', claimed.history_revision::TEXT,
+        'analysisSchemaVersion', claimed.analysis_schema_version
+      )
+      ORDER BY claimed.user_id, claimed.scope_game_uid, claimed.server_scope
+    ),
+    '[]'::JSONB
+  )
+  INTO v_scope_jobs
+  FROM claimed;
+
+  RETURN jsonb_build_object(
+    'leaseId', p_lease_id,
+    'leaseSeconds', v_lease_seconds,
+    'ownerJobs', v_owner_jobs,
+    'scopeJobs', v_scope_jobs
+  );
+END;
+$$;
+
+COMMIT;
+-- <<< END MIGRATION: active/177_prioritize_active_personal_analysis_jobs.sql
 

--- a/supabase/migrations/177_prioritize_active_personal_analysis_jobs.sql
+++ b/supabase/migrations/177_prioritize_active_personal_analysis_jobs.sql
@@ -1,0 +1,404 @@
+-- 177: prioritize active personal-analysis users and claim complete user batches.
+--
+-- The previous global FIFO queue processed one owner and one scope per run.
+-- A historical backfill therefore placed active users behind thousands of
+-- dormant rows, while remaining scopes could starve whenever another owner
+-- job existed. This migration keeps revision-safe leases but chooses users as
+-- the scheduling unit and lets an authenticated API request promote its own
+-- missing/stale read model through a service-role-only RPC.
+
+BEGIN;
+
+ALTER TABLE public.personal_analysis_owner_state
+  ADD COLUMN IF NOT EXISTS priority_requested_at TIMESTAMPTZ;
+
+ALTER TABLE public.personal_analysis_scope_state
+  ADD COLUMN IF NOT EXISTS priority_requested_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_personal_analysis_owner_state_priority
+  ON public.personal_analysis_owner_state (
+    priority_requested_at ASC NULLS LAST,
+    next_attempt_at,
+    dirty_since,
+    user_id
+  )
+  WHERE snapshot_revision < history_revision;
+
+CREATE INDEX IF NOT EXISTS idx_personal_analysis_scope_state_priority
+  ON public.personal_analysis_scope_state (
+    priority_requested_at ASC NULLS LAST,
+    next_attempt_at,
+    dirty_since,
+    user_id,
+    scope_game_uid,
+    server_scope
+  )
+  WHERE snapshot_revision < history_revision;
+
+CREATE OR REPLACE FUNCTION public.clear_personal_analysis_priority_when_fresh()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  IF NEW.snapshot_revision = NEW.history_revision THEN
+    NEW.priority_requested_at := NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS clear_personal_analysis_owner_priority_when_fresh
+  ON public.personal_analysis_owner_state;
+CREATE TRIGGER clear_personal_analysis_owner_priority_when_fresh
+  BEFORE UPDATE OF snapshot_revision, history_revision
+  ON public.personal_analysis_owner_state
+  FOR EACH ROW
+  EXECUTE FUNCTION public.clear_personal_analysis_priority_when_fresh();
+
+DROP TRIGGER IF EXISTS clear_personal_analysis_scope_priority_when_fresh
+  ON public.personal_analysis_scope_state;
+CREATE TRIGGER clear_personal_analysis_scope_priority_when_fresh
+  BEFORE UPDATE OF snapshot_revision, history_revision
+  ON public.personal_analysis_scope_state
+  FOR EACH ROW
+  EXECUTE FUNCTION public.clear_personal_analysis_priority_when_fresh();
+
+CREATE OR REPLACE FUNCTION public.prioritize_personal_analysis_jobs(
+  p_user_id UUID,
+  p_scope_game_uid TEXT DEFAULT NULL,
+  p_server_scope TEXT DEFAULT NULL,
+  p_force_owner BOOLEAN DEFAULT FALSE,
+  p_force_scope BOOLEAN DEFAULT FALSE
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  -- clock_timestamp() changes within a transaction. This preserves FIFO
+  -- ordering even when maintenance code prioritizes several users in one
+  -- transaction; repeated requests still retain their first timestamp below.
+  v_requested_at TIMESTAMPTZ := clock_timestamp();
+  v_game_uid TEXT := NULLIF(btrim(p_scope_game_uid), '');
+  v_server_scope TEXT := NULLIF(btrim(p_server_scope), '');
+  v_owner_rows INTEGER := 0;
+  v_scope_rows INTEGER := 0;
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'personal_analysis_user_id_required';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.history AS history_row
+    WHERE history_row.user_id = p_user_id
+  ) THEN
+    RETURN jsonb_build_object(
+      'queued', FALSE,
+      'ownerRows', 0,
+      'scopeRows', 0
+    );
+  END IF;
+
+  INSERT INTO public.personal_analysis_owner_state (
+    user_id,
+    history_revision,
+    snapshot_revision,
+    dirty_since,
+    analysis_schema_version,
+    priority_requested_at
+  )
+  VALUES (
+    p_user_id,
+    1,
+    -1,
+    v_requested_at,
+    1,
+    v_requested_at
+  )
+  ON CONFLICT (user_id) DO NOTHING;
+
+  INSERT INTO public.personal_analysis_scope_state (
+    user_id,
+    scope_game_uid,
+    server_scope,
+    history_revision,
+    snapshot_revision,
+    dirty_since,
+    analysis_schema_version,
+    priority_requested_at
+  )
+  SELECT DISTINCT
+    history_row.user_id,
+    public.normalize_personal_analysis_game_uid(
+      history_row.user_id,
+      history_row.game_uid
+    ),
+    COALESCE(NULLIF(btrim(history_row.server_scope), ''), 'legacy'),
+    1,
+    -1,
+    v_requested_at,
+    1,
+    v_requested_at
+  FROM public.history AS history_row
+  WHERE history_row.user_id = p_user_id
+    AND (
+      v_game_uid IS NULL
+      OR public.normalize_personal_analysis_game_uid(
+        history_row.user_id,
+        history_row.game_uid
+      ) = v_game_uid
+    )
+    AND (
+      v_server_scope IS NULL
+      OR COALESCE(NULLIF(btrim(history_row.server_scope), ''), 'legacy') = v_server_scope
+    )
+  ON CONFLICT (user_id, scope_game_uid, server_scope) DO NOTHING;
+
+  UPDATE public.personal_analysis_owner_state AS state
+  SET
+    snapshot_revision = CASE
+      WHEN p_force_owner AND state.snapshot_revision = state.history_revision
+        THEN GREATEST(-1, state.history_revision - 1)
+      ELSE state.snapshot_revision
+    END,
+    dirty_since = COALESCE(state.dirty_since, v_requested_at),
+    priority_requested_at = COALESCE(state.priority_requested_at, v_requested_at),
+    lease_id = CASE
+      WHEN state.lease_expires_at <= v_requested_at THEN NULL
+      ELSE state.lease_id
+    END,
+    lease_expires_at = CASE
+      WHEN state.lease_expires_at <= v_requested_at THEN NULL
+      ELSE state.lease_expires_at
+    END
+  WHERE state.user_id = p_user_id
+    AND (
+      state.snapshot_revision < state.history_revision
+      OR p_force_owner
+    );
+  GET DIAGNOSTICS v_owner_rows = ROW_COUNT;
+
+  UPDATE public.personal_analysis_scope_state AS state
+  SET
+    snapshot_revision = CASE
+      WHEN p_force_scope AND state.snapshot_revision = state.history_revision
+        THEN GREATEST(-1, state.history_revision - 1)
+      ELSE state.snapshot_revision
+    END,
+    dirty_since = COALESCE(state.dirty_since, v_requested_at),
+    priority_requested_at = COALESCE(state.priority_requested_at, v_requested_at),
+    lease_id = CASE
+      WHEN state.lease_expires_at <= v_requested_at THEN NULL
+      ELSE state.lease_id
+    END,
+    lease_expires_at = CASE
+      WHEN state.lease_expires_at <= v_requested_at THEN NULL
+      ELSE state.lease_expires_at
+    END
+  WHERE state.user_id = p_user_id
+    AND (v_game_uid IS NULL OR state.scope_game_uid = v_game_uid)
+    AND (v_server_scope IS NULL OR state.server_scope = v_server_scope)
+    AND (
+      state.snapshot_revision < state.history_revision
+      OR p_force_scope
+    );
+  GET DIAGNOSTICS v_scope_rows = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'queued', v_owner_rows > 0 OR v_scope_rows > 0,
+    'ownerRows', v_owner_rows,
+    'scopeRows', v_scope_rows,
+    'requestedAt', v_requested_at
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.prioritize_personal_analysis_jobs(
+  UUID,
+  TEXT,
+  TEXT,
+  BOOLEAN,
+  BOOLEAN
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.prioritize_personal_analysis_jobs(
+  UUID,
+  TEXT,
+  TEXT,
+  BOOLEAN,
+  BOOLEAN
+) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.claim_personal_analysis_jobs(
+  p_lease_id UUID,
+  p_limit INTEGER DEFAULT 1,
+  p_lease_seconds INTEGER DEFAULT 50
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_limit INTEGER := LEAST(GREATEST(COALESCE(p_limit, 1), 1), 5);
+  v_lease_seconds INTEGER := LEAST(
+    GREATEST(COALESCE(p_lease_seconds, 50), 30),
+    55
+  );
+  v_scope_limit_per_user INTEGER := 20;
+  v_user_ids UUID[] := ARRAY[]::UUID[];
+  v_owner_jobs JSONB := '[]'::JSONB;
+  v_scope_jobs JSONB := '[]'::JSONB;
+BEGIN
+  IF p_lease_id IS NULL THEN
+    RAISE EXCEPTION 'personal_analysis_lease_id_required';
+  END IF;
+
+  SELECT COALESCE(array_agg(candidate.user_id ORDER BY candidate.rank), ARRAY[]::UUID[])
+  INTO v_user_ids
+  FROM (
+    SELECT
+      due.user_id,
+      row_number() OVER (
+        ORDER BY
+          (max(due.priority_requested_at) IS NULL),
+          min(due.priority_requested_at) ASC NULLS LAST,
+          min(due.next_attempt_at) NULLS FIRST,
+          min(due.dirty_since) NULLS FIRST,
+          due.user_id
+      ) AS rank
+    FROM (
+      SELECT
+        state.user_id,
+        state.priority_requested_at,
+        state.next_attempt_at,
+        state.dirty_since
+      FROM public.personal_analysis_owner_state AS state
+      WHERE state.snapshot_revision < state.history_revision
+        AND (state.lease_expires_at IS NULL OR state.lease_expires_at <= statement_timestamp())
+        AND (state.next_attempt_at IS NULL OR state.next_attempt_at <= statement_timestamp())
+
+      UNION ALL
+
+      SELECT
+        state.user_id,
+        state.priority_requested_at,
+        state.next_attempt_at,
+        state.dirty_since
+      FROM public.personal_analysis_scope_state AS state
+      WHERE state.snapshot_revision < state.history_revision
+        AND (state.lease_expires_at IS NULL OR state.lease_expires_at <= statement_timestamp())
+        AND (state.next_attempt_at IS NULL OR state.next_attempt_at <= statement_timestamp())
+    ) AS due
+    GROUP BY due.user_id
+    ORDER BY rank
+    LIMIT v_limit
+  ) AS candidate;
+
+  IF COALESCE(array_length(v_user_ids, 1), 0) = 0 THEN
+    RETURN jsonb_build_object(
+      'leaseId', p_lease_id,
+      'leaseSeconds', v_lease_seconds,
+      'ownerJobs', v_owner_jobs,
+      'scopeJobs', v_scope_jobs
+    );
+  END IF;
+
+  WITH claimed AS (
+    UPDATE public.personal_analysis_owner_state AS state
+    SET
+      lease_id = p_lease_id,
+      lease_expires_at = statement_timestamp() + make_interval(secs => v_lease_seconds)
+    WHERE state.user_id = ANY(v_user_ids)
+      AND state.snapshot_revision < state.history_revision
+      AND (state.lease_expires_at IS NULL OR state.lease_expires_at <= statement_timestamp())
+      AND (state.next_attempt_at IS NULL OR state.next_attempt_at <= statement_timestamp())
+    RETURNING
+      state.user_id,
+      state.history_revision,
+      state.analysis_schema_version
+  )
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'kind', 'owner',
+        'userId', claimed.user_id,
+        'historyRevision', claimed.history_revision::TEXT,
+        'analysisSchemaVersion', claimed.analysis_schema_version
+      )
+      ORDER BY claimed.user_id
+    ),
+    '[]'::JSONB
+  )
+  INTO v_owner_jobs
+  FROM claimed;
+
+  WITH ranked AS (
+    SELECT
+      state.user_id,
+      state.scope_game_uid,
+      state.server_scope,
+      row_number() OVER (
+        PARTITION BY state.user_id
+        ORDER BY
+          state.priority_requested_at ASC NULLS LAST,
+          state.next_attempt_at NULLS FIRST,
+          state.dirty_since NULLS FIRST,
+          state.scope_game_uid,
+          state.server_scope
+      ) AS scope_rank
+    FROM public.personal_analysis_scope_state AS state
+    WHERE state.user_id = ANY(v_user_ids)
+      AND state.snapshot_revision < state.history_revision
+      AND (state.lease_expires_at IS NULL OR state.lease_expires_at <= statement_timestamp())
+      AND (state.next_attempt_at IS NULL OR state.next_attempt_at <= statement_timestamp())
+  ),
+  claimed AS (
+    UPDATE public.personal_analysis_scope_state AS state
+    SET
+      lease_id = p_lease_id,
+      lease_expires_at = statement_timestamp() + make_interval(secs => v_lease_seconds)
+    FROM ranked
+    WHERE ranked.scope_rank <= v_scope_limit_per_user
+      AND state.user_id = ranked.user_id
+      AND state.scope_game_uid = ranked.scope_game_uid
+      AND state.server_scope = ranked.server_scope
+      AND state.snapshot_revision < state.history_revision
+      AND (state.lease_expires_at IS NULL OR state.lease_expires_at <= statement_timestamp())
+      AND (state.next_attempt_at IS NULL OR state.next_attempt_at <= statement_timestamp())
+    RETURNING
+      state.user_id,
+      state.scope_game_uid,
+      state.server_scope,
+      state.history_revision,
+      state.analysis_schema_version
+  )
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'kind', 'scope',
+        'userId', claimed.user_id,
+        'scopeGameUid', claimed.scope_game_uid,
+        'serverScope', claimed.server_scope,
+        'historyRevision', claimed.history_revision::TEXT,
+        'analysisSchemaVersion', claimed.analysis_schema_version
+      )
+      ORDER BY claimed.user_id, claimed.scope_game_uid, claimed.server_scope
+    ),
+    '[]'::JSONB
+  )
+  INTO v_scope_jobs
+  FROM claimed;
+
+  RETURN jsonb_build_object(
+    'leaseId', p_lease_id,
+    'leaseSeconds', v_lease_seconds,
+    'ownerJobs', v_owner_jobs,
+    'scopeJobs', v_scope_jobs
+  );
+END;
+$$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- 限制 `building/stale` 自动轮询为 30s → 60s → 120s → 300s，达到上限后停止；building poll 保持原状态，不再与 loading 文案反复闪烁
- 增加活跃用户 FIFO 优先级，按用户领取 owner 与最多 20 个 scope，一次模型构建完成同用户快照，避免 2300+ 历史任务造成队列饥饿
- 阻止“scope 仍有历史却发布空快照”的错误 fresh 状态；将 Worker 调度改为不可变 Vercel Deployment URL，并通过 Automation Bypass 穿过 Team SSO
- 增加 PostgreSQL 17 队列行为测试并纳入 CI；migration 177 已在生产事务部署并验证

## Test plan

- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run test:unit`（218 files / 1197 tests）
- [x] `npm run test:personal-analysis-queue`
- [x] PostgreSQL 17 baseline smoke
- [x] `npm run build`
- [x] Vercel Worker-only Production 使用 `--skip-domain` 部署 Ready
- [x] 正式前台域名仍指向用户 promote 的旧版本

## Deployment notes

- Production migration 177 已部署；没有清空或重置现有 state/snapshot
- GitHub Variables 已指向不可变 Worker Deployment URL，`PERSONAL_ANALYSIS_WORKER_MAX_BATCHES=4`
- Vercel Automation Bypass 已轮换并同步到 GitHub Secret；旧 bypass 已撤销
- 合并后需手动运行一次 `Personal Analysis Worker`，确认 bypass → Worker → Supabase 发布链路