### PR TITLE
修复附加寻访分析接口500

### DIFF
--- a/api/__tests__/accountGachaData.test.js
+++ b/api/__tests__/accountGachaData.test.js
@@ -518,6 +518,50 @@ describe('/api/account-gacha-data', () => {
     expect(JSON.stringify(res.body.scope)).not.toContain('pool-other');
   });
 
+  it('projects reserved-character view keys in memory without breaking PostgREST select syntax', async () => {
+    const adminClient = createAdminClient();
+    adminClient.__state.accountSnapshots['game-1::server:2'].payload.dashboard = {
+      views: {
+        '__group_extra:reconstruction': { total: 56 },
+        'pool-other': { total: 34 },
+      },
+      timelineViews: {
+        'zh-CN': {
+          '__group_extra:reconstruction': [{ id: 'reconstruction-zh' }],
+          'pool-other': [{ id: 'other-zh' }],
+        },
+      },
+    };
+    mocks.getSupabaseAdminClient.mockReturnValue(adminClient);
+    const res = createJsonResponseRecorder();
+
+    await accountGachaDataHandler(createRequest({
+      url: '/api/account-gacha-data?mode=analysis&accountKey=game-1%3A%3Aserver%3A2&viewKey=__group_extra%3Areconstruction&locale=zh-CN',
+    }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.scope.dashboard).toEqual({
+      views: { '__group_extra:reconstruction': { total: 56 } },
+      timelineViews: {
+        'zh-CN': {
+          '__group_extra:reconstruction': [{ id: 'reconstruction-zh' }],
+        },
+      },
+    });
+    const snapshotReads = adminClient.__state.selectCalls.filter((call) => (
+      call.table === 'personal_analysis_snapshots'
+      && call.filters.some((filter) => (
+        filter.column === 'scope_kind' && filter.value === 'account'
+      ))
+    ));
+    expect(snapshotReads).toHaveLength(1);
+    expect(snapshotReads[0].selection).toContain('payload');
+    expect(snapshotReads[0].selection).not.toContain(
+      'views->__group_extra:reconstruction'
+    );
+    expect(JSON.stringify(res.body.scope)).not.toContain('pool-other');
+  });
+
   it('returns building instead of falling back to a full history read when no snapshot exists', async () => {
     const adminClient = createAdminClient();
     adminClient.__state.ownerSnapshot = null;

--- a/api/_routes/root/account-gacha-data.js
+++ b/api/_routes/root/account-gacha-data.js
@@ -606,6 +606,10 @@ function buildProjectedAccountPayload(data, viewKey, locale) {
   };
 }
 
+function isSafePostgrestJsonPathSegment(value) {
+  return /^[A-Za-z0-9_-]+$/.test(String(value || ''));
+}
+
 async function loadProjectedPersonalAnalysisAccountSnapshot(
   dbClient,
   userId,
@@ -614,6 +618,23 @@ async function loadProjectedPersonalAnalysisAccountSnapshot(
 ) {
   if (!viewKey) {
     return loadPersonalAnalysisSnapshot(dbClient, userId, 'account', scopeKey);
+  }
+
+  if (
+    !isSafePostgrestJsonPathSegment(viewKey)
+    || !isSafePostgrestJsonPathSegment(locale)
+  ) {
+    const snapshot = await loadPersonalAnalysisSnapshot(
+      dbClient,
+      userId,
+      'account',
+      scopeKey
+    );
+    if (!snapshot) return null;
+    return {
+      ...snapshot,
+      payload: projectTransientScopePayload(snapshot.payload, viewKey, locale),
+    };
   }
 
   const selection = [
@@ -2268,6 +2289,7 @@ export const __internal = {
   loadProjectedPersonalAnalysisAccountSnapshot,
   loadPersonalAnalysisSnapshot,
   loadPersonalAnalysisScopeState,
+  isSafePostgrestJsonPathSegment,
   prioritizePersonalAnalysisJobs,
   requestImmediatePersonalAnalysisDispatch,
   readHistoryPageScope,


### PR DESCRIPTION
## Summary

- 修复附加寻访分组 `viewKey` 含冒号时触发 PostgREST `PGRST100` 的生产 500
- 对安全路径段继续使用 JSONB 数据库投影；包含保留字符的键改为 owner/account 限定读取后在服务端投影
- 新增 `__group_extra:reconstruction` 回归测试，确保响应只包含目标视图且动态 select 不包含冒号路径

## Test plan

- [x] 针对性 ESLint 与 `accountGachaData` 32 项测试
- [x] `npm run lint`
- [x] `npm run test:unit`（239 files / 1316 tests）
- [x] `npm test`
- [x] `npm run build`
