### PR TITLE
fix(analysis): 保留聚合视图并过滤武器赠送

### DIFF
--- a/api/__tests__/officialImportRecordNormalizer.test.js
+++ b/api/__tests__/officialImportRecordNormalizer.test.js
@@ -3,6 +3,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   filterOfficialImportPullRecords,
+  getOfficialImportEventName,
   getOfficialImportRecordKind,
   hasActionableImportIdentityIssues,
   hasWriteBlockingImportIssues,
@@ -103,6 +104,42 @@ describe('officialImportRecordNormalizer', () => {
     expect(isOfficialImportNonPullRecord(records[10])).toBe(true);
     expect(filterOfficialImportPullRecords(records)).toHaveLength(10);
     expect(filterOfficialImportPullRecords(records).every((record) => record.kind === 'draw')).toBe(true);
+  });
+
+  it('filters both weapon gift events while preserving normal weapon claims', () => {
+    const records = [
+      {
+        kind: 'draw',
+        nameText: '军列申领',
+        poolId: 'weponbox_1_0_1',
+        seqId: '1',
+        weaponId: 'wpn_normal',
+        weaponName: '浪潮',
+        rarity: 6,
+        gachaTs: '1780000000000',
+      },
+      {
+        nameText: '武库赠礼-军列申领',
+        poolId: 'weponbox_1_0_1',
+        seqId: '2',
+        weaponName: '补充武库·军列',
+        gachaTs: '1780000000000',
+      },
+      {
+        name_text: '军列赠礼－军列申领',
+        poolId: 'weponbox_1_0_1',
+        seqId: '3',
+        weaponId: 'wpn_up',
+        weaponName: '四三式·高降',
+        rarity: 6,
+        gachaTs: '1780000000000',
+      },
+    ];
+
+    expect(getOfficialImportEventName(records[1])).toBe('武库赠礼-军列申领');
+    expect(isOfficialImportNonPullRecord(records[1])).toBe(true);
+    expect(isOfficialImportNonPullRecord(records[2])).toBe(true);
+    expect(filterOfficialImportPullRecords(records)).toEqual([records[0]]);
   });
 
   it('blocks records without an official sequence id', () => {

--- a/shared/officialImportRecordNormalizer.js
+++ b/shared/officialImportRecordNormalizer.js
@@ -1,6 +1,7 @@
 const ISSUE_SEVERITIES = new Set(['blocking', 'review', 'info']);
 const ACTIONABLE_IDENTITY_ISSUE_CODES = new Set(['MISSING_ITEM_ID_AND_NAME', 'MISSING_ITEM_ID', 'MISSING_ITEM_NAME']);
 const NON_PULL_RECORD_KINDS = new Set(['gift_intel_book']);
+const WEAPON_GIFT_EVENT_NAME_PATTERN = /^(?:武库赠礼|军列赠礼)(?:\s*[-－—–:：]\s*.+)?$/u;
 
 function firstDefined(...values) {
   return values.find((value) => value !== undefined && value !== null && String(value).trim() !== '');
@@ -14,8 +15,18 @@ export function getOfficialImportRecordKind(record = {}) {
   return normalizeText(firstDefined(record.kind, record.recordKind, record.record_kind)).toLowerCase();
 }
 
+export function getOfficialImportEventName(record = {}) {
+  return normalizeText(firstDefined(
+    record.nameText,
+    record.name_text,
+    record.eventName,
+    record.event_name
+  ));
+}
+
 export function isOfficialImportNonPullRecord(record = {}) {
-  return NON_PULL_RECORD_KINDS.has(getOfficialImportRecordKind(record));
+  return NON_PULL_RECORD_KINDS.has(getOfficialImportRecordKind(record))
+    || WEAPON_GIFT_EVENT_NAME_PATTERN.test(getOfficialImportEventName(record));
 }
 
 export function filterOfficialImportPullRecords(records = []) {
@@ -234,6 +245,7 @@ export function summarizeOfficialImportIssues(records) {
 
 export default {
   filterOfficialImportPullRecords,
+  getOfficialImportEventName,
   getOfficialImportRecordKind,
   hasActionableImportIdentityIssues,
   hasBlockingImportIssues,

--- a/src/utils/__tests__/cloudDataSync.test.js
+++ b/src/utils/__tests__/cloudDataSync.test.js
@@ -92,4 +92,24 @@ describe('analysis cloud snapshot', () => {
     expect(targets.switchPool).toHaveBeenCalledWith('pool-b');
     expect(setHistory).not.toHaveBeenCalled();
   });
+
+  it('应用聚合视图快照时保留虚拟卡池 ID，不回退到第一个真实卡池', () => {
+    const targets = {
+      setPools: vi.fn(),
+      switchPool: vi.fn(),
+      switchGameAccount: vi.fn(),
+      preferredPoolId: '__group_limited',
+      analysisStore: { applyAnalysis: vi.fn(() => true) },
+    };
+    const snapshot = createAnalysisSnapshot();
+    snapshot.analysis.scope.dashboard = {
+      views: {
+        __group_limited: { stats: { total: 8 } },
+      },
+    };
+
+    expect(applyCloudAnalysisToStores(snapshot, targets)).toBe(true);
+    expect(targets.switchPool).toHaveBeenCalledWith('__group_limited');
+    expect(targets.switchPool).not.toHaveBeenCalledWith('pool-a');
+  });
 });

--- a/src/utils/cloudDataSync.js
+++ b/src/utils/cloudDataSync.js
@@ -1,6 +1,7 @@
 import { getPreferredPoolId } from './poolSelectionUtils';
 import { STORAGE_KEYS, writeStorageValue } from './storageUtils.js';
 import { isGameAccountSelectionMatch } from './gameAccountMetadata.js';
+import { isPoolGroupId } from './poolGroupUtils.js';
 import usePersonalAnalysisStore, {
   PERSONAL_ANALYSIS_AVAILABILITIES,
 } from '../stores/usePersonalAnalysisStore.js';
@@ -147,6 +148,14 @@ function resolveAnalysisAccountKey(analysis) {
 }
 
 function resolvePreferredPoolIdFromAnalysis(pools, analysis, preferredPoolId = null) {
+  const normalizedPreferredPoolId = normalizeText(preferredPoolId);
+  const requestedView = normalizedPreferredPoolId
+    ? analysis?.scope?.dashboard?.views?.[normalizedPreferredPoolId]
+    : null;
+  if (isPoolGroupId(normalizedPreferredPoolId) && requestedView) {
+    return normalizedPreferredPoolId;
+  }
+
   const pullCounts = analysis?.scope?.selector?.poolPullCounts;
   if (!pullCounts || typeof pullCounts !== 'object' || Array.isArray(pullCounts)) {
     return null;
@@ -160,8 +169,8 @@ function resolvePreferredPoolIdFromAnalysis(pools, analysis, preferredPoolId = n
     return null;
   }
 
-  if (preferredPoolId && poolIdsWithData.includes(preferredPoolId)) {
-    return preferredPoolId;
+  if (normalizedPreferredPoolId && poolIdsWithData.includes(normalizedPreferredPoolId)) {
+    return normalizedPreferredPoolId;
   }
 
   const idsWithData = new Set(poolIdsWithData);


### PR DESCRIPTION
## Summary
- 修复 PERF-013 后聚合卡池视图被分析快照刷新重置到首个真实卡池的问题
- 将“武库赠礼”和“军列赠礼”纳入官方非抽卡事件过滤，避免武器池导入产生空历史记录
- 保持正常武器申领记录不受影响，并复用现有旧空占位精确修复链路

## Test plan
- [x] `npx vitest run src/utils/__tests__/cloudDataSync.test.js api/__tests__/officialImportRecordNormalizer.test.js`
- [x] 修改文件 ESLint
- [x] `npx vite build`
- [ ] GitHub CI