### PR TITLE
docs(release): 更新生产证据与分支闭拢说明

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,8 +16,9 @@
 
 涉及认证或数据库时：
 
-- [ ] 已说明候选 baseline 覆盖范围和共享生产迁移记录
-- [ ] 认证 166/167 已重新生成/验证 baseline，且未混入其他 worktree 的 159 候选
+- [ ] 已说明当前 baseline 覆盖范围、前向迁移顺序和共享生产迁移记录
+- [ ] 已核对其他活动 worktree 的同号候选，且未把历史迁移尾号当作当前编号依据
+- [ ] 已重新生成/验证 baseline，并在临时 PostgreSQL 中执行相关 smoke / 合同测试
 - [ ] 已运行 Phase A/B 与 Phase C/D 认证专项验证
 - [ ] 已区分本地测试、真实浏览器回归、授权后集成和生产部署状态
 - [ ] 未提交 identity key、OAuth secret、邮箱 challenge、临时凭据或真实邮箱数据

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,6 +17,10 @@ flowchart LR
   Browser --> ImportBackend["Private CN / INTL import backend"]
   ImportBackend --> ImportStaging["Official import staging"]
   ImportStaging --> SupabaseDb
+  Browser --> AnalysisApi["/api/account-gacha-data\nanalysis mode"]
+  AnalysisApi --> AnalysisSnapshot["personal_analysis_snapshots"]
+  AnalysisScheduler["Supabase pg_cron + pg_net"] --> AnalysisWorker["/api/personal-analysis-worker"]
+  AnalysisWorker --> AnalysisSnapshot
   PublicApi --> PublicCache["Serverless public cache"]
   PublicCache --> SupabaseDb["Supabase PostgreSQL"]
   Admin["Admin UI"] --> AdminApi["Protected admin API"]
@@ -29,7 +33,8 @@ flowchart LR
 
 - 公共数据：生产浏览器统一请求同源 `/api/*`，由 Serverless 层访问 Supabase。
 - 私有数据：用户抽卡历史、个人排行、工单、账号恢复和后台数据保持鉴权隔离与 `no-store`。
-- 认证：邮箱凭据继续由 Supabase Auth 管理；第三方 provider 经同源 OAuth bridge 接入，两条入口都以 `auth.users` UUID 为锚点并创建 `app_sessions`。`AUTH-HARDEN-001` Phase A–D 与候选验收已完成并由 `5dd8505` 固化；生产数据库已于 2026-08-02 按 166 → 167 完成迁移和权限/回填核验，API 与主线代码尚未部署。LinuxDo 代码提交为 `b8d14d2`，因无法申请 Connect Client 下调为 P3，保持关闭且不阻塞认证发布。
+- 认证：邮箱凭据继续由 Supabase Auth 管理；第三方 provider 经同源 OAuth bridge 接入，两条入口都以 `auth.users` UUID 为锚点并创建 `app_sessions`。`AUTH-HARDEN-001` Phase A–D、PR #14 和生产 166–168 已完成；LinuxDo 因无法申请 Connect Client 下调为 P3，保持关闭且不阻塞主线。
+- 个人分析：浏览器只读取 owner/account 快照，不在请求期下载完整历史重新聚合。活跃用户通过 service-role-only RPC 排队并即时触发 `pg_net`，`pg_cron` 每分钟兜底；Worker 使用 lease / revision 防止并发覆盖和陈旧发布。
 - 管理与自动化：后台写入、cron 和手动 ops 共享服务端 helper，写入成功后 best-effort 刷新公共缓存版本。
 - 私有导入：CN / INTL 后端负责访问官方数据源、过滤情报书等非寻访事件、规范化、问题分类和内部暂存，随后自动通过数据库 RPC 原子提交；可定位的未知角色 / 武器记录写入后由 `history_anomalies` 提醒用户核对。再次导入时，只有被官方数据精确证明为非寻访事件的旧版四星未知占位才会原子移除并重算对应卡池保底。
 - 仓库边界：`backend/` 只公开测试与数据契约需要的兼容 helper，不代表完整私有部署包。
@@ -41,9 +46,9 @@ flowchart LR
 | 入口 | `src/main.jsx`、`src/AppRouter.jsx` | React 挂载、主题、双端路由、Speed Insights |
 | 桌面端 | `src/App.jsx`、`src/GachaAnalyzer.jsx`、`src/components/app/DesktopAppRoutes.jsx` | 桌面壳层、初始化、主导航 |
 | 移动端 | `src/mobile/MobileApp.jsx`、`src/mobile/layouts/MobileLayout.jsx` | 移动壳层、底栏、移动页面 |
-| 状态 | `src/stores/*` | auth、pool、history、app 公共状态 |
+| 状态 | `src/stores/*` | auth、pool、history、个人数据请求生命周期与个人分析快照 |
 | 公共读取 | `src/services/publicResourceClient.js` | 同源请求、公共版本、内存缓存、localStorage snapshot |
-| 私有写入 | `src/services/accountGachaDataService.js`、`src/hooks/app/useCloudSync.js`、`src/utils/cloudDataSync.js` | 账号历史读取、精确变更、池信息和账号数据同步 |
+| 私有读取 / 写入 | `src/services/accountGachaDataService.js`、`src/hooks/app/useCloudSync.js`、`src/utils/cloudDataSync.js` | 个人分析读取、历史分页、精确变更、池信息和 owner 隔离同步 |
 | 官方导入 | `src/features/import/useOfficialImportController.js`、`src/features/import/ImportManager.jsx` | 创建 `import-full` 后台任务、轮询 `import-status`、结果刷新、导入后异常提示，以及兼容期遗留审阅元数据清理 |
 
 当前仍需后续治理的前端复杂点：
@@ -60,7 +65,8 @@ flowchart LR
 | 后台 API | `api/_routes/root/admin.js` | 管理面板统一入口 |
 | 自动化 API | `api/_routes/root/ops-automation.js`、`api/_lib/runOpsAutomation.js` | cron、manual、job graph、review bundle |
 | BOT / 开发者 API | `api/_routes/dev/**/*`、`api/_routes/integrations/**/*` | 受保护只读接口和平台绑定 |
-| 账号历史 | `api/_routes/root/account-gacha-data.js` | 私有历史并行分页读取、精确编辑 / 删除和别名解析 |
+| 账号历史与个人分析 | `api/_routes/root/account-gacha-data.js` | 私有历史分页、owner/account 快照投影、活跃排队、精确编辑 / 删除和别名解析 |
+| 个人分析 Worker | `api/_routes/root/personal-analysis-worker.js`、`api/_lib/personalAnalysisWorker.js` | 受保护 Worker、按用户领取 owner/scope、构建并发布 revision 快照 |
 | 历史异常 | `api/_routes/root/history-anomalies.js`、`admin-history-anomalies.js` | 用户当前作用域提醒与超级管理员复核 |
 | 认证与会话 | `api/_routes/root/auth-oauth.js`、`api/_lib/linuxDoOAuth.js`、`auth-session.js`、`account-email-action.js`、`account-email-verify.js`、`account-password-setup.js`、`account-security-state.js` | OAuth transaction、GitHub/LinuxDo provider 编排、统一站点 Session、邮箱归属、首次设密与凭据状态 |
 
@@ -91,7 +97,11 @@ DB-OPTIMIZE-001 的当前结论：线上 `history` 体积主要来自索引，�
 
 账号历史读取先取得用户精确记录数，再以固定并发分页读取必要列；卡池目录、可见池和账号历史在前端同步阶段并行等待。该优化不改变完整作用域定位、审计或保底重算语义。
 
-认证数据库面由 166/167 提供：admin RPC 权限、OAuth transaction、Session 撤销、规范化邮箱唯一归属、一次性邮箱 challenge、首次设密能力、临时凭据认证层门禁和版本化 identity hash keyring。共享生产 schema 已于 2026-08-02 完成 166/167；集成 baseline 覆盖到 167，API 部署仍需独立授权。
+认证数据库面由 166–172 提供：admin RPC 权限、OAuth transaction、Session 撤销、规范化邮箱唯一归属、一次性邮箱 challenge、首次设密能力、临时凭据认证层门禁、版本化 identity hash keyring，以及受审批 / 证据约束的旧邮箱空壳修复与原子隔离。已确认生产历史包括 166–168；后续运行态仍以实时核验为准，不能仅由 Git 文件推定。
+
+个人分析数据库面由 173–180 提供：owner/scope revision、快照队列、catalog 依赖失效、活跃用户优先级、Worker lease、`pg_cron + pg_net` 调度、5 秒全局节流和优先级感知即时派发。常规 Worker 保持 `PERSONAL_ANALYSIS_WORKER_BACKFILL_ENABLED=false`，历史回填只能在维护窗口显式开启。
+
+附加寻访数据库面由 181–183 提供：`extra_subtype / extra_rule_profile / extra_series_key / extra_series_phase`，并把产品语义区分为 `reconstruction`、`reconstruction_claim` 和 `special`。相同分类贯穿可见卡池 RPC、管理写入、官方导入、版本绑定、分析与模拟器；旧 `type=extra` 仍作为粗粒度兼容类型。
 
 ## 6. 运营自动化
 
@@ -123,6 +133,7 @@ npm run build
 npm run perf:report
 npm run test:supabase-baseline
 npm run test:supabase-baseline:smoke
+npm run test:personal-analysis-queue
 npm run test:auth-hardening-phase-a
 npm run test:auth-hardening-phase-cd
 npm run test:public-api-boundary

--- a/docs/AUTH_SECURITY_HARDENING.md
+++ b/docs/AUTH_SECURITY_HARDENING.md
@@ -6,11 +6,11 @@
 
 > 2026-08-04 生产跟进：迁移 171 与 operator 批准已生产应用。真实确认请求暴露出 GoTrue v2.188.1 Admin 更新用户会依次修改 email identity、Auth email、metadata 与封禁状态，活动 intent 的冻结触发器因此正确拒绝中间状态。迁移 `172_quarantine_oauth_email_artifact_atomically.sql` 将空壳用户、唯一 email identity、intent metadata 与长期封禁收口为同一数据库事务，并为活动空壳 identity 增加精确冻结触发器；应用层改用该 RPC，结果不明时先幂等重试，仍无法确认则进入人工协调状态，不再错误释放 claim。专项测试同时覆盖 identity 并发新增拒绝、用户更新失败后的整笔回滚，以及 v1/v2 最终隔离不变量。
 
-状态：`AUTH-HARDEN-001` 本地安全实现与候选验收已完成；远端审查和生产发布由 `AUTH-HARDEN-RELEASE-001` 继续跟踪。本地提交不等于已发布或允许部署。
+状态：`AUTH-HARDEN-001`、`AUTH-HARDEN-RELEASE-001`、PR #14 与生产 166–168 已完成；后续只在具体认证回归或 provider 任务中继续。历史提交或候选文件仍不自动授权新的生产迁移、账号修改或 provider 开放。
 
 > 新会话入口：根目录 `SESSION_HANDOFF.md` 与 `todo` 的 `AUTH-HARDEN-001`。
-> 实现目录：`D:\Learning\Endfield Gacha\_tmp\auth-hardening-integration`；当前检出纯认证候选 `fix/auth-hardening-integration`，Phase A–D 基线提交为 `5dd8505`。
-> Phase A、B、C、D 已集成到最新主线基线、重编号为 166/167，并由本地提交 `5dd8505` 固化；2026-08-02 已按 166 → 167 应用到生产数据库并完成权限/回填核验。远端审查发现的历史 identity 哈希、直连 RLS 撤销和凭据生命周期缺口由前向迁移 168 与配套代码收口；**168 尚未应用到生产，API 尚未部署，代码尚未合入主线**。
+> 当前实现入口：主站 `main`。旧 `_tmp/auth-hardening-integration` worktree 已于 2026-08-27 审计闭拢；Phase A–D 历史基线提交为 `5dd8505`，不再从已删除分支恢复。
+> Phase A、B、C、D 已重编号为 166/167，并于 2026-08-02 应用到生产数据库完成权限 / 回填核验；远端审查缺口由前向迁移 168 与配套代码收口。迁移 168、PR #14、认证 API 与主线发布均已完成；后续 169–172 的运行态仍需按具体生产任务实时核验，不能仅由 Git 文件推定。
 > LinuxDo 属于独立低优先级任务 `AUTH-LINUXDO-002`：实现继续隔离在 `feat/linuxdo-oauth`，不进入本认证候选；目前无法申请隔离 Connect Client，前后端开关保持关闭，不再阻塞认证发布。
 
 ## 当前决策
@@ -22,45 +22,40 @@
 
 ## 当前仓库事实
 
-- 生产版本仍是 `v4.5.4`；主站标准迁移链与主站 baseline 到 158。共享生产库另有独立抽奖项目迁移 160–165，这些迁移不属于主站 baseline，也不得复制或重复执行。
-- 远端 `origin/main` 当前为 `4826b76`（PR #13 合并提交）。
-- 主工作树仍检出 `feat/perf-013-history-scope` @ `2a4f909`，有大量用户改动和已完成的认证文档改动；**不要在这棵树上实现认证代码**。
-- **认证集成 worktree（当前唯一认证实现树）：**
-  - 路径：`D:\Learning\Endfield Gacha\_tmp\auth-hardening-integration`
-  - 认证分支：`fix/auth-hardening-integration` @ `5dd8505`（基于最新 `origin/main` `4826b76` 的本地认证提交）
-  - LinuxDo 存储分支：`feat/linuxdo-oauth`（从 `5dd8505` 切出，代码与文档均保持隔离，未合并、未部署）
-- `.agent-tmp/oauth-password-email-conflict` 是已注册的 `fix/oauth-password-email-conflict` worktree @ `ea7466a`，含未提交邮箱目标绑定、首次设密和遗留冲突修复候选；仅作参考，不是实现基线。
-- 命令工具对 `_tmp/*` / `.agent-tmp/*` 的 `working_directory` 可能错误回退到主工作树。Git 使用 `git -C "D:\Learning\Endfield Gacha\_tmp\auth-hardening-integration"`；npm 使用 `npm --prefix "D:\Learning\Endfield Gacha\_tmp\auth-hardening-integration"`。
-- `origin/main` 的主站标准迁移尾号是 158；共享生产数据库另含抽奖 160–165，并已于 2026-08-02 应用认证 166/167。主线代码和 API 部署仍未包含认证候选。
+- 生产版本文档口径仍是 `v4.5.4`；2026-08-27 主应用目录为干净的 `main@d186a425d5fb29aad940b4f08027744dfecbc602`，与 `origin/main` 一致，GitHub-connected Vercel Production Ready。
+- 当前生成 baseline 覆盖到 migration 183。已确认生产历史包括独立抽奖 160–165、认证 166–168 和正式导入修复 170；169–172 等后续合同的运行态仍需按具体任务实时核验，不从 Git 文件自动推定。
+- 旧认证 Phase A、Magic Link 和 `oauth-password-email-conflict` worktree 已于 2026-08-27 逐文件审计并闭拢；重复的 159/160/170 候选和旧跨系统手工修复脚本不再是恢复入口。
+- 当前认证实现、测试与专题文档均以主站 `main` 为准。LinuxDo 仍保留在独立 `feat/linuxdo-oauth` 分支，未推送、未合并、未部署，外部 Client 条件恢复前保持关闭。
+- Git / npm 默认入口为 `D:\Learning\Endfield Gacha\gacha-analyzer`。含 `.env.local` 的辅助目录只保留环境配置并停在 detached `main`；不得读取、公开或自动覆盖其中配置。
 
-### migration 编号的跨 worktree 冲突（不是同分支重复文件）
+### migration 编号历史冲突（已收口，仅用于解释最终编号）
 
 | 位置 | 文件名 | 含义 |
 | --- | --- | --- |
-| 认证集成 worktree | `166_harden_admin_profile_and_oauth_transactions.sql` | Phase A/B forward migration；已避开抽奖 160–165 |
-| 认证集成 worktree | `167_harden_account_credentials_and_identity_keys.sql` | Phase C/D forward migration；紧随 Phase A/B |
-| 认证集成 worktree | `168_close_auth_review_findings.sql` | 远端审查修复；历史 identity 原子迁移、直连 RLS Session 门禁和首次设密并发串行化；尚未生产应用 |
-| 主脏树性能线 | `159_add_history_scope_read_models.sql` | 本地性能 RPC/索引；**不得部署**；合入前必须重编号 |
-| 邮箱候选 worktree | `159_bind_email_verification_to_target.sql` | Phase C 参考候选；**不得部署**；合入前必须重编号 |
+| 当前主线 | `166_harden_admin_profile_and_oauth_transactions.sql` | Phase A/B forward migration；避开抽奖 160–165 |
+| 当前主线 | `167_harden_account_credentials_and_identity_keys.sql` | Phase C/D forward migration；紧随 Phase A/B |
+| 当前主线 | `168_close_auth_review_findings.sql` | 历史 identity 原子迁移、直连 RLS Session 门禁和首次设密并发串行化；已生产应用 |
+| 已闭拢旧候选 | `159_add_history_scope_read_models.sql` | 旧性能候选，不属于当前迁移链，不得补执行 |
+| 已闭拢旧候选 | `159_bind_email_verification_to_target.sql` | 旧邮箱参考候选，已被 167 与后续原子化流程取代，不得补执行 |
 
 - 2026-08-02 迁移前只读核对确认运行版本为 `v4.5.4`、抽奖 160–165 存在、性能 159 与认证结构不存在；随后已创建受限完整备份并按 166 → 167 应用认证迁移。生产库没有主站应用级 migration ledger。
 - 因此认证初始两条迁移使用连续新号 166/167，审查修复继续使用 168。性能线 159 和旧邮箱候选 159 仍是独立未发布候选，不进入本认证分支。
-- 166/167 已按编号顺序生产应用；168 是本 PR 新增的前向迁移，必须在部署依赖其 RPC 的 API 前单独授权并执行。性能线 159 仍未应用，也不得因编号较小而补执行。
+- 166/167/168 已按编号顺序生产应用并随 PR #14 发布。旧 159 候选未应用，也不得因编号较小而补执行；当前新迁移编号只看实时 baseline、所有活动候选与生产记录。
 
 ## 实现进度
 
 | 阶段 | 状态 |
 | --- | --- |
-| 文档 / 任务账本 / 交接 | 已同步到 2026-08-02 实现与浏览器证据 |
-| 认证实现 worktree | 已创建；Phase A–D 由 `5dd8505` 固化；LinuxDo 保持在独立分支，不进入本候选 |
-| Phase A 代码（admin RPC + OAuth transaction） | **完成并提交；数据库面已生产应用，API 未部署** |
-| Phase B 代码（双凭据、刷新凭据、session 撤销、兼容 JWT 回查） | **完成并提交；数据库面已生产应用，API 未部署** |
-| Phase C 代码（候选邮箱、首次设密、临时密码到期） | **完成并提交；数据库面已生产应用，API 未部署** |
-| Phase D 代码（identity keyring、原子认领、补偿恢复） | **完成并提交；数据库面已生产应用，API 未部署** |
+| 文档 / 任务账本 / 交接 | 已同步到 2026-08-27 当前主线与发布事实 |
+| 认证实现入口 | 当前主站 `main`；Phase A–D 历史由 `5dd8505` 固化，旧认证 worktree 已闭拢 |
+| Phase A 代码（admin RPC + OAuth transaction） | **完成、合入并生产发布** |
+| Phase B 代码（双凭据、刷新凭据、session 撤销、兼容 JWT 回查） | **完成、合入并生产发布** |
+| Phase C 代码（候选邮箱、首次设密、临时密码到期） | **完成、合入并生产发布** |
+| Phase D 代码（identity keyring、原子认领、补偿恢复） | **完成、合入并生产发布** |
 | 候选验收（GitHub / 邮箱 / 安全属性） | **已完成**：GitHub 核心闭环使用隔离浏览器验证；跨浏览器 transaction、link Session 切换、callback 重放及邮箱/凭据状态机由专项自动化与本地 PostgreSQL 17 验证；已授权 App 无取消控件的限制已记录 |
 | LinuxDo provider | **转 `AUTH-LINUXDO-002`（P3）**：代码和自动化合同已完成，真实 Client 验收因外部条件暂停，不阻塞本任务 |
-| 生产 migration | **部分完成**：166 → 167、3,095 个确认邮箱归属回填、83 条 identity key 版本和角色权限核验通过；审查修复迁移 168 尚未生产应用 |
-| push / 合并 / API 部署 | **转 `AUTH-HARDEN-RELEASE-001`**：候选进入远端审查；合并和部署仍需独立授权 |
+| 生产 migration | **当前阶段完成**：166 → 168、确认邮箱归属回填、identity key 版本和角色权限核验通过；后续 169–172 运行态按具体任务实时核验 |
+| push / 合并 / API 部署 | **完成**：PR #14、主线 CI 和 Vercel Production 已完成；后续生产动作继续独立授权 |
 
 ## 认证数据流
 
@@ -138,7 +133,7 @@ flowchart LR
 
 ### Phase A：关闭直接攻击面
 
-**实现状态：已由 `5dd8505` 提交；数据库面已生产应用，API 尚未部署。**
+**实现状态：已完成、合入并生产发布；`5dd8505` 仅作为历史候选基线。**
 
 1. migration `166_harden_admin_profile_and_oauth_transactions.sql`：
    - 撤销 `PUBLIC/anon/authenticated` 对 `admin_update_profile` 的 EXECUTE；仅 `service_role`
@@ -153,7 +148,7 @@ flowchart LR
 
 ### Phase B：统一请求身份与凭据撤销
 
-**实现状态：已由 `5dd8505` 提交；数据库面已生产应用，API 尚未部署。**
+**实现状态：已完成、合入并生产发布；`5dd8505` 仅作为历史候选基线。**
 
 1. `POST /api/auth/session` bootstrap 只走 `resolveBearerRequestUser`；已有 Cookie 不能覆盖待引导用户。
 2. `resolveAuthenticatedRequestUser`：有 Authorization 时先校验 Bearer；若同时有有效 Cookie session，比较 user ID，不一致返回 `auth_identity_conflict`。
@@ -165,7 +160,7 @@ flowchart LR
 
 ### Phase C：收敛邮箱与密码状态机
 
-**实现状态：已由 `5dd8505` 提交；数据库面已生产应用，API 尚未部署。**
+**实现状态：已完成、合入并生产发布；`5dd8505` 仅作为历史候选基线。**
 
 1. 建立规范化候选邮箱/pending 状态；验证前不把候选值写成 canonical `profiles.email`。migration 167 新增 `account_email_ownerships`（规范化唯一归属）与 `account_email_challenges`（一次性挑战，绑定 `user_id + target_email + 版本`，`start/consume` RPC 以 advisory lock + 条件更新保证单次消费）。
 2. 邮箱归属使用数据库唯一约束或原子 claim，不用全量扫描 Auth 用户替代唯一性。
@@ -179,7 +174,7 @@ flowchart LR
 
 ### Phase D：稳定 OAuth identity
 
-**实现状态：已由 `5dd8505` 提交；数据库面已生产应用，API 尚未部署。**
+**实现状态：已完成、合入并生产发布；`5dd8505` 仅作为历史候选基线。**
 
 1. 引入独立、版本化的 identity hash key：`api/_lib/identityHash.js`（`AUTH_IDENTITY_HASH_KEY_CURRENT/PREVIOUS`，缺 key 安全关闭、版本冲突拒绝，与 state 密钥解耦）。
 2. 支持旧 key 查询、新 key 写入和登录时原子迁移（`claim_oauth_identity` RPC 双 hash 双读，owner 不可变、hash split 拒绝）；迁移完成前不得轮换/退役旧 key。

--- a/docs/CLOSEOUT_LEDGER.md
+++ b/docs/CLOSEOUT_LEDGER.md
@@ -13,6 +13,8 @@
 
 | 范围 | 当前证据 | 收口目标 | 归属任务 |
 | --- | --- | --- | --- |
+| 个人分析快照 | owner/account revision、持久快照、活跃用户 FIFO、`pg_cron + pg_net` 即时派发、45 秒多批 Worker、渐进检查与同 owner Session 保护已由 PR #23–#25 合入并完成生产 E2E；含冒号 viewKey 已有回归测试和生产 HTTP 200 证据。 | `完成`。后续只做 dispatch / HTTP 2xx 和生产 Web Vitals 低频观察；出现具体回归再拆 BUG，不重新打开旧 PERF 候选。 | `PERF-013 / UX-FLOW-001 / PROD-OBS-001` |
+| 附加寻访子类型 | migrations 181–183、管理写入、官方导入、版本绑定、个人分析、模拟器和桌面 / 移动展示均区分 `reconstruction`、`reconstruction_claim`、`special`；生产最终字段、约束、触发器、受限晋升 RPC、种子卡池与绑定已只读核验。 | `完成`。保留 `type=extra` 作为粗粒度兼容；未来增加新规则模板时必须扩展统一 capability / profile 合同，不能只按 ID 前缀猜测。 | `EXTRA-POOL-SUBTYPE-001 / PROD-OBS-001` |
 | 官方 ID 回填 | `src/utils/canonicalEntityUtils.js` 仍将 `char_manual_*`、`weapon_manual_*` 和 `*_manual_*` 卡池 ID 归类为 `manual_placeholder`；admin 卡池测试仍创建 `special_manual_*` alias。 | 先提供非破坏性审计，再把 placeholder 映射到官方 ID，保留 alias，更新外键，校验导出兼容，并产出回滚报告。 | `DATA-NEW-017` |
 | 公共卡池分析 | 已新增 `public_pool_analytics_cache` / `public_pool_trend_cache` 与 `refresh_public_analytics_cache()`；`api/_lib/publicAnalytics.js` 优先读取预聚合缓存，单池指标和趋势点都带 `analyticsMeta.partial / cacheKey / cacheVersion / warning`。缺表或缺行时，趋势端点返回空 `points`，单池端点只降级为 bounded count。 | 后续补生产迁移应用、真实 refresh 耗时观测、长期 source/meta 看板，以及更多安全 admin/ops 写入点接线；继续避免请求期扫描原始 history。 | `API-003 / STATS-004` |
 | 开发者 API 审核 | admin 路由支持 `reviewNote`，设置页展示 `review_note`；`DeveloperApiPanel.jsx` 审核、拒绝、撤销和重新启用时会提示填写备注。审核结果通知已能在 `DEVELOPER_API_REVIEW_MAIL_OUTBOX_ENABLED=true` 且 `MAIL_OUTBOX_WORKER_ENABLED=true` 时写入邮件 outbox，且邮件入队失败不会阻断审核。 | 后续补用户设置页更明确的下一步动作、历史审核记录、管理员风险提示和更完整责任链；邮件真实投递仍受队列处理器、演练模式、紧急停发开关和投递监控保护。 | `DEVAPI-004` |

--- a/docs/GIT_WORKFLOW.md
+++ b/docs/GIT_WORKFLOW.md
@@ -82,10 +82,10 @@ chore:发布v4.4.1
 认证和数据库变更需要额外分层：
 
 1. 合入前分别检查主站标准链、各 worktree 候选和共享生产库迁移记录；不能只按本地文件名推断生产编号。
-2. 本认证 worktree 已按共享生产 schema 将迁移重编号为 166/167，避开独立抽奖 160–165；性能线和旧邮箱候选的同号 159 未进入认证分支。
-3. 认证集成 baseline 已重新生成并验证到 167；生产数据库已于 2026-08-02 按 166 → 167 执行并完成权限、回填、函数和触发器核验。
-4. 数据库已先于依赖新列/RPC 的 API 应用；API 部署仍需独立授权。每个 provider 都必须完成各自真实浏览器回归后才开放，GitHub 验收不能替代 LinuxDo/QQ 验收。
-5. commit、push、部署、生产 migration 和生产账号修改分别授权，不能相互推定。
+2. 迁移编号必须以当前 baseline 覆盖范围、所有活动 worktree 候选和共享生产记录共同决定；不能只把旧文档中的 166/167 或任意尾号当作下一编号。
+3. 变更 `archive/` 或 `migrations/` 后必须重新生成 baseline，并验证每个 migration block 的内容一致性和临时 PostgreSQL smoke；当前覆盖范围看 baseline 头部与 `supabase/README.md`。
+4. 数据库必须先于依赖新列 / RPC 的 API 应用；API 部署仍需独立授权。每个 provider 都必须完成各自真实浏览器回归后才开放，GitHub 验收不能替代 LinuxDo / QQ 验收。
+5. commit、push、部署、生产 migration 和生产账号修改分别授权，不能相互推定。生产已存在等价最终 schema 时，重编号后的仓库迁移不得重复执行。
 
 主站正常发布不直接运行 `vercel deploy --prod`。只有用户明确批准紧急回滚、promotion 或切换已有部署时，才使用 Vercel CLI；操作前必须说明目标部署 URL / ID，操作后必须重新核对生产 alias。独立状态页等其他 Vercel 项目是不同部署目标，不得与主站发布混用。
 
@@ -119,5 +119,15 @@ git diff --check
 5. 同步更新 `todo` 和 `SESSION_HANDOFF.md`。
 
 根目录 `todo` 与 `SESSION_HANDOFF.md` 位于主仓库外层，不会随 `gacha-analyzer` 提交自动进入 Git。发布交接时必须单独检查它们是否已经同步，仓库内文档提交不要假定会包含这两个文件。
+
+## 已合并分支闭拢
+
+分支或 worktree 的“已合并”不能只看名称或 PR 标题。闭拢前必须：
+
+1. 用 `git merge-base --is-ancestor <branch> main` 确认 tip 已进入当前 `main`。
+2. 检查该 worktree 的跟踪改动、未跟踪文件和被忽略的本地配置；未提交内容需要逐文件判断是否已被主线覆盖。
+3. `.env.local`、密钥、数据库导出、Git bundle 和恢复材料不得因删除 worktree 被顺带清理；不得读取或复制其值到公开文档。
+4. 干净 worktree 可先移除再用 `git branch -d` 删除分支；有本地环境配置的目录可切到 detached `main` 保留环境，分支仍用非强制删除。
+5. 远端分支只在确认已合并且没有开放 PR 后删除；本地与远端引用分别核验，不使用强推或按名称批量猜测。
 
 历史改写只适合本练习项目或已明确允许的仓库。协作仓库默认用新增修复提交解决问题。

--- a/docs/PERSONAL_ANALYSIS_WORKER.md
+++ b/docs/PERSONAL_ANALYSIS_WORKER.md
@@ -111,3 +111,11 @@ Migration 177 增加 `priority_requested_at`。分析 API 发现当前用户的 
 
 如果 Vault、pg_cron 或 pg_net 不可用，不能把用户请求伪装成“正在排队”。分析 API
 会返回明确的 `personal_analysis_queue_unavailable` 503，页面保留可诊断的错误状态。
+
+## 已核对的发布证据
+
+- PR #24 已将 Session 循环修复、即时派发、短间隔轻量检查和 45 秒多批 Worker 合入主线；PR #25 已修复含 `:` 的附加寻访 `viewKey` 触发 PostgREST `PGRST100 / HTTP 500` 的问题。
+- 2026-08-27 当前发布主线为 `d186a425d5fb29aad940b4f08027744dfecbc602`，GitHub CI 与 GitHub-connected Vercel Production 已核对为成功 / Ready。
+- 1789 条合成历史、4 个游戏账号、25 个卡池的一次真实浏览器冷启动观测约为 `13.1s`，其中 `building → ready` 约 `6s`，未观察到 `building → loading` 或页面错误。该结果是一次脱敏 E2E 观测，不是 SLA 或长期性能承诺。
+- 生产带 `viewKey=__group_extra:reconstruction` 的真实登录请求返回 HTTP 200 / `availability=ready`。测试账号没有该分组记录时目标视图为空属于正常结果；单元测试覆盖有数据时只投影目标 view / locale。
+- 源码 migration 181–183 是为解决分支编号冲突后的前向文件名。生产数据库只读核验确认已经具备最终字段、约束、触发器、受限 RPC、种子卡池与版本绑定；不要据此重复执行重编号迁移。

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
 - `docs/AUTH_SECURITY_HARDENING.md`：Phase A–D 本地候选、认证不变量、迁移重编号、真实浏览器回归和发布门禁
 - `docs/PROJECT_GUIDE.md`：部署、环境变量、数据库维护、静态资源和 changelog 摘要
 - `docs/CODEMAP.md`：代码入口和主要模块索引
+- `docs/PERSONAL_ANALYSIS_WORKER.md`：个人分析快照队列、Supabase `pg_cron + pg_net` 调度、应急入口与生产核验
 - `docs/CLOSEOUT_LEDGER.md`：已上线但仍依赖 placeholder / fallback / 隐藏入口的功能收口总账
 - `docs/ACCOUNT_ALL_CLOSEOUT.md`：全部账号汇总的保留、关闭和重新开放条件
 - `docs/SELF_HOSTED_MAIL.md`：自建邮件平台选型、投递基础设施、outbox / suppression / 防刷预算边界和后续决策点

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -2,6 +2,15 @@
 
 本文件的未勾选项是下一次发布时复用的模板，不代表当前 `v4.5.4` 尚未完成。`v4.5.4` 已在 `78f5ed1 chore:发布v4.5.4` 收口：迁移 157 / 158 已执行且没有主动修改异常记录，CN / INTL 后端 `1.6.3` 健康，GitHub CI 全部通过，GitHub 触发的 Vercel Production 部署 Ready，生产首页、移动入口、bootstrap 版本、双区公网健康和 CORS 预检均通过。
 
+## v4.5.4 后主线补充记录（2026-08-27）
+
+- [x] PR #24 已合入个人分析 Session 循环修复、Supabase `pg_cron + pg_net` 调度、即时派发、短间隔检查、45 秒多批 Worker，以及重构寻访 / 重构申领 / 特殊附加寻访支持。
+- [x] PR #25 已修复含 PostgREST 保留字符的分析 `viewKey` 触发 `PGRST100 / HTTP 500`；生产真实登录请求返回 HTTP 200 / ready。
+- [x] 当前发布主线为 `d186a425d5fb29aad940b4f08027744dfecbc602`；GitHub CI、Vercel Preview 和 GitHub-connected Vercel Production 均已核对成功 / Ready。
+- [x] 完整回归为 239 个 Vitest 文件 / 1316 项测试，另通过 ESLint、公共验证、个人分析队列 PostgreSQL 合同、baseline smoke 和生产构建。
+- [x] 1789 条合成历史的一次真实浏览器冷启动观测约 `13.1s`；这是观测值，不是 SLA。
+- [x] 新环境 baseline 覆盖到 migration 183；生产已只读核验个人分析调度和附加寻访最终数据库合同。重编号后的 181–183 不应因此重复执行。
+
 ## 代码
 
 - [ ] 版本号和 changelog 已更新
@@ -57,7 +66,7 @@
 
 LinuxDo 代码、配置和验收矩阵由独立分支 `feat/linuxdo-oauth` 维护，不进入本认证候选。外部申请条件恢复前保持关闭，也不阻塞本次认证发布。
 
-## OAuth 邮箱旧空壳自助修复（migration 169）
+## OAuth 邮箱旧空壳自助修复（migration 169；以下保留为该阶段发布检查历史）
 
 - [x] `npm run test:auth-hardening-phase-cd` 已在临时 PostgreSQL 17 中完成候选识别、错码计数与持久预算、一次性验证、claim 原子占用、归属转移、完成及 restrictive RLS 门禁闭环
 - [x] API 专项覆盖：先提示可修复、重新核对候选、发送 6 位验证码、验证和显式确认分离、协调状态不暴露内部错误、确认必须绑定发起时的站点会话
@@ -85,7 +94,7 @@ LinuxDo 代码、配置和验收矩阵由独立分支 `feat/linuxdo-oauth` 维�
 
 ## 部署
 
-- [x] Supabase baseline / migration 状态已确认到本分支 169；生产当前到 168
+- [x] 当时 Supabase baseline / migration 状态已确认到本分支 169、生产到 168；当前覆盖范围必须读取 baseline 头部与 `supabase/README.md`，不能沿用该历史尾号
 - [x] 迁移前已通过 SSH 只读核对生产 schema；独立抽奖 160–165 存在且不属于主站 baseline，认证结构当时不存在
 - [x] 认证初始迁移已定为 166/167，审查修复使用前向迁移 168；baseline 已重新生成并在临时 PostgreSQL 中完整验证
 - [x] 生产数据库已按 166 → 167 执行；3,095 个邮箱归属、83 条 identity key 版本、权限/触发器/函数断言和 `site_version=v4.5.4` 均核对通过

--- a/docs/STALWART_DEPLOYMENT_GUIDE.md
+++ b/docs/STALWART_DEPLOYMENT_GUIDE.md
@@ -4,7 +4,7 @@
 
 ## 认证发布额外门禁
 
-`AUTH-HARDEN-001` Phase A–D 与本地候选验收已完成；生产数据库已于 2026-08-02 按 166 → 167 部署邮箱归属、首次设密和临时凭据数据库能力，API 尚未部署。测试邮件只证明投递链路，不能证明账号归属或 OAuth/Session 安全闭环；LinuxDo 已降为 P3，真实 Connect Client 验收完成前保持关闭且不阻塞本发布。
+`AUTH-HARDEN-001` Phase A–D、PR #14 和生产 166–168 已完成，认证 API 已随主线发布。测试邮件只证明投递链路，不能证明账号归属或 OAuth / Session 安全闭环；LinuxDo 已降为 P3，真实 Connect Client 验收完成前保持关闭且不阻塞本发布。
 
 ## 结论
 


### PR DESCRIPTION
## Summary

- 同步认证、个人分析和附加寻访的生产发布状态与架构说明
- 更新迁移编号、baseline 验证和 PR 检查口径，避免沿用过期阶段结论
- 补充已合并分支的安全闭拢规则与发布证据索引

## Test plan

- [x] `git diff --check`
- [x] 逐文件核对文档与当前主线、生产迁移记录一致